### PR TITLE
New streams need the appropriate flow control values

### DIFF
--- a/h2/connection.py
+++ b/h2/connection.py
@@ -253,6 +253,10 @@ class H2Connection(object):
         s = H2Stream(stream_id)
         s.max_inbound_frame_size = self.max_inbound_frame_size
         s.max_outbound_frame_size = self.max_outbound_frame_size
+        s.outbound_flow_control_window = (
+            self.remote_settings[SettingsFrame.INITIAL_WINDOW_SIZE]
+        )
+
         self.streams[stream_id] = s
         self.highest_stream_id = stream_id
         return s

--- a/test/test_flow_control_window.py
+++ b/test/test_flow_control_window.py
@@ -151,3 +151,19 @@ class TestFlowControl(object):
         c.acknowledge_settings(events[0])
 
         assert c.flow_control_window(1) == 128000
+
+    def test_new_streams_have_flow_control_per_settings(self, frame_factory):
+        """
+        After a SETTINGS_INITIAL_WINDOW_SIZE change is received, new streams
+        have appropriate new flow control windows.
+        """
+        c = h2.connection.H2Connection()
+
+        f = frame_factory.build_settings_frame(
+            settings={SettingsFrame.INITIAL_WINDOW_SIZE: 128000}
+        )
+        events = c.receive_data(f.serialize())
+        c.acknowledge_settings(events[0])
+
+        c.send_headers(1, self.example_request_headers)
+        assert c.flow_control_window(1) == 128000


### PR DESCRIPTION
Once the setting has changed, we really do need to persist the value.