### PR TITLE
Remote settings handling

### DIFF
--- a/h2/connection.py
+++ b/h2/connection.py
@@ -587,8 +587,9 @@ class H2Connection(object):
             ConnectionInputs.RECV_SETTINGS
         )
 
-        # This is an ack of the local settings. Right now, do nothing.
+        # This is an ack of the local settings.
         if 'ACK' in frame.flags:
+            self.local_settings.acknowledge()
             return [], events
 
         # Add the new settings.

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -16,6 +16,7 @@ from hpack.hpack import Encoder, Decoder
 from .events import WindowUpdated, RemoteSettingsChanged, PingAcknowledged
 from .exceptions import ProtocolError, NoSuchStreamError, FlowControlError
 from .frame_buffer import FrameBuffer
+from .settings import Settings
 from .stream import H2Stream
 
 
@@ -208,12 +209,9 @@ class H2Connection(object):
         # outbound side of the connection.
         self.outbound_flow_control_window = 65535
 
-        # This might want to be an extensible class that does sensible stuff
-        # with defaults. For now, a dict will do.
-        self.local_settings = {}
-        self.remote_settings = {
-            SettingsFrame.INITIAL_WINDOW_SIZE: 65535,
-        }
+        # Objects that store settings, including defaults.
+        self.local_settings = Settings(client=client_side)
+        self.remote_settings = Settings(client=not client_side)
 
         # Buffer for incoming data.
         self.incoming_buffer = FrameBuffer(server=not client_side)
@@ -429,16 +427,15 @@ class H2Connection(object):
         assert isinstance(event, RemoteSettingsChanged)
         self.state_machine.process_input(ConnectionInputs.SEND_SETTINGS)
 
-        if SettingsFrame.INITIAL_WINDOW_SIZE in event.changed_settings:
-            setting = event.changed_settings[SettingsFrame.INITIAL_WINDOW_SIZE]
+        changes = self.remote_settings.acknowledge()
+
+        if SettingsFrame.INITIAL_WINDOW_SIZE in changes:
+            setting = changes[SettingsFrame.INITIAL_WINDOW_SIZE]
             self._flow_control_change_from_settings(
                 setting.original_value,
                 setting.new_value,
             )
 
-        self.remote_settings.update(
-            (k, v.new_value) for k, v in event.changed_settings.items()
-        )
         f = SettingsFrame(0)
         f.flags.add('ACK')
         self._prepare_for_sending([f])
@@ -593,6 +590,9 @@ class H2Connection(object):
         # This is an ack of the local settings. Right now, do nothing.
         if 'ACK' in frame.flags:
             return [], events
+
+        # Add the new settings.
+        self.remote_settings.update(frame.settings)
 
         events.append(RemoteSettingsChanged.from_settings(
             self.remote_settings, frame.settings

--- a/h2/events.py
+++ b/h2/events.py
@@ -9,7 +9,7 @@ Events are returned by the H2 state machine to allow implementations to keep
 track of events triggered by receiving data. Each time data is provided to the
 H2 state machine it processes the data and returns a list of Event objects.
 """
-from collections import namedtuple
+from .settings import ChangedSetting
 
 
 class RequestReceived(object):
@@ -71,11 +71,6 @@ class RemoteSettingsChanged(object):
     settings are acceptable, and then acknowledge them. If they are not
     acceptable, the user should close the connection.
     """
-    #: A value structure for storing changed settings.
-    ChangedSetting = namedtuple(
-        'ChangedSetting', ['setting', 'original_value', 'new_value']
-    )
-
     def __init__(self):
         self.changed_settings = {}
 
@@ -92,7 +87,7 @@ class RemoteSettingsChanged(object):
         e = cls()
         for setting, new_value in new_settings.items():
             original_value = old_settings.get(setting)
-            change = cls.ChangedSetting(setting, original_value, new_value)
+            change = ChangedSetting(setting, original_value, new_value)
             e.changed_settings[setting] = change
 
         return e

--- a/h2/settings.py
+++ b/h2/settings.py
@@ -12,6 +12,12 @@ import collections
 from hyperframe.frame import SettingsFrame
 
 
+#: A value structure for storing changed settings.
+ChangedSetting = collections.namedtuple(
+    'ChangedSetting', ['setting', 'original_value', 'new_value']
+)
+
+
 class Settings(collections.MutableMapping):
     """
     An object that encapsulates HTTP/2 settings state.

--- a/h2/settings.py
+++ b/h2/settings.py
@@ -56,12 +56,22 @@ class Settings(collections.MutableMapping):
         """
         The settings have been acknowledged, either by the user (remote
         settings) or by the remote peer (local settings).
+
+        :returns: A dict of {setting: ChangedSetting} that were applied.
         """
+        changed_settings = {}
+
         # If there is more than one setting in the list, we have a setting
         # value outstanding. Update them.
-        for v in self._settings.values():
+        for k, v in self._settings.items():
             if len(v) > 1:
-                v.popleft()
+                old_setting = v.popleft()
+                new_setting = v[0]
+                changed_settings[k] = ChangedSetting(
+                    k, old_setting, new_setting
+                )
+
+        return changed_settings
 
     # Provide easy-access to well known settings.
     @property

--- a/h2/settings.py
+++ b/h2/settings.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+"""
+h2/settings
+~~~~~~~~~~~
+
+This module contains a HTTP/2 settings object. This object provides a simple
+API for manipulating HTTP/2 settings, keeping track of both the current active
+state of the settings and the unacknowledged future values of the settings.
+"""
+import collections
+
+from hyperframe.frame import SettingsFrame
+
+
+class Settings(collections.MutableMapping):
+    """
+    An object that encapsulates HTTP/2 settings state.
+
+    HTTP/2 Settings are a complex beast. Each party, remote and local, has its
+    own settings and a view of the other party's settings. When a settings
+    frame is emitted by a peer it cannot assume that the new settings values
+    are in place until the remote peer acknowledges the setting. In principle,
+    multiple settings changes can be "in flight" at the same time, all with
+    different values.
+
+    This object encapsulates this mess. It provides a dict-like interface to
+    settings, which return the *current* values pf the settings in question.
+    Additionally, it keeps track of the stack of proposed values: each time an
+    acknowledgement is sent/received, it updates the current values with the
+    stack of proposed values.
+
+    Finally, this object understands what the default values of the HTTP/2
+    settings are, and sets those defaults appropriately.
+    """
+    def __init__(self, client=True):
+        # Backing object for the settings. This is a dictionary of
+        # (setting: [list of values]), where the first value in the list is the
+        # current value of the setting. Strictly this doesn't use lists but
+        # instead uses collections.deque to avoid repeated memory allocations.
+        #
+        # This contains the default values for HTTP/2.
+        self._settings = {
+            SettingsFrame.HEADER_TABLE_SIZE: collections.deque([4096]),
+            SettingsFrame.ENABLE_PUSH: collections.deque([int(client)]),
+            SettingsFrame.INITIAL_WINDOW_SIZE: collections.deque([65535]),
+            SettingsFrame.SETTINGS_MAX_FRAME_SIZE: collections.deque([16384]),
+        }
+
+    def acknowledge(self):
+        """
+        The settings have been acknowledged, either by the user (remote
+        settings) or by the remote peer (local settings).
+        """
+        # If there is more than one setting in the list, we have a setting
+        # value outstanding. Update them.
+        for v in self._settings.values():
+            if len(v) > 1:
+                v.popleft()
+
+    # Implement the MutableMapping API.
+    def __getitem__(self, key):
+        val = self._settings[key][0]
+
+        # Things that were created when a setting was received should stay
+        # KeyError'd.
+        if val is None:
+            raise KeyError
+
+        return val
+
+    def __setitem__(self, key, value):
+        try:
+            items = self._settings[key]
+        except KeyError:
+            items = collections.deque([None])
+            self._settings[key] = items
+
+        items.append(value)
+
+    def __delitem__(self, key):
+        del self._settings[key]
+
+    def __iter__(self):
+        return self._settings.__iter__()
+
+    def __len__(self):
+        return len(self._settings)

--- a/h2/settings.py
+++ b/h2/settings.py
@@ -57,6 +57,51 @@ class Settings(collections.MutableMapping):
             if len(v) > 1:
                 v.popleft()
 
+    # Provide easy-access to well known settings.
+    @property
+    def header_table_size(self):
+        """
+        The current value of the SETTINGS_HEADER_TABLE_SIZE setting.
+        """
+        return self[SettingsFrame.HEADER_TABLE_SIZE]
+
+    @header_table_size.setter
+    def header_table_size(self, value):
+        self[SettingsFrame.HEADER_TABLE_SIZE] = value
+
+    @property
+    def enable_push(self):
+        """
+        The current value of the SETTINGS_ENABLE_PUSH setting.
+        """
+        return self[SettingsFrame.ENABLE_PUSH]
+
+    @enable_push.setter
+    def enable_push(self, value):
+        self[SettingsFrame.ENABLE_PUSH] = value
+
+    @property
+    def initial_window_size(self):
+        """
+        The current value of the SETTINGS_INITIAL_WINDOW_SIZE setting.
+        """
+        return self[SettingsFrame.INITIAL_WINDOW_SIZE]
+
+    @initial_window_size.setter
+    def initial_window_size(self, value):
+        self[SettingsFrame.INITIAL_WINDOW_SIZE] = value
+
+    @property
+    def max_frame_size(self):
+        """
+        The current value of the SETTINGS_MAX_FRAME_SIZE setting.
+        """
+        return self[SettingsFrame.SETTINGS_MAX_FRAME_SIZE]
+
+    @max_frame_size.setter
+    def max_frame_size(self, value):
+        self[SettingsFrame.SETTINGS_MAX_FRAME_SIZE] = value
+
     # Implement the MutableMapping API.
     def __getitem__(self, key):
         val = self._settings[key][0]

--- a/test/test_settings.py
+++ b/test/test_settings.py
@@ -124,3 +124,31 @@ class TestSettings(object):
 
         s.acknowledge()
         assert s[SettingsFrame.HEADER_TABLE_SIZE] == 4096
+
+    def test_settings_getters(self):
+        """
+        Getters exist for well-known settings.
+        """
+        s = h2.settings.Settings(client=True)
+
+        assert s.header_table_size == s[SettingsFrame.HEADER_TABLE_SIZE]
+        assert s.enable_push == s[SettingsFrame.ENABLE_PUSH]
+        assert s.initial_window_size == s[SettingsFrame.INITIAL_WINDOW_SIZE]
+        assert s.max_frame_size == s[SettingsFrame.SETTINGS_MAX_FRAME_SIZE]
+
+    def test_settings_setters(self):
+        """
+        Setters exist for well-known settings.
+        """
+        s = h2.settings.Settings(client=True)
+
+        s.header_table_size = 0
+        s.enable_push = 1
+        s.initial_window_size = 2
+        s.max_frame_size = 3
+
+        s.acknowledge()
+        assert s[SettingsFrame.HEADER_TABLE_SIZE] == 0
+        assert s[SettingsFrame.ENABLE_PUSH] == 1
+        assert s[SettingsFrame.INITIAL_WINDOW_SIZE] == 2
+        assert s[SettingsFrame.SETTINGS_MAX_FRAME_SIZE] == 3

--- a/test/test_settings.py
+++ b/test/test_settings.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+"""
+test_settings
+~~~~~~~~~~~~~
+
+Test the Settings object.
+"""
+import pytest
+
+import h2.settings
+
+from hyperframe.frame import SettingsFrame
+
+
+class TestSettings(object):
+    """
+    Test the Settings object behaves as expected.
+    """
+    def test_settings_defaults_client(self):
+        """
+        The Settings object begins with the appropriate defaults for clients.
+        """
+        s = h2.settings.Settings(client=True)
+
+        assert s[SettingsFrame.HEADER_TABLE_SIZE] == 4096
+        assert s[SettingsFrame.ENABLE_PUSH] == 1
+        assert s[SettingsFrame.INITIAL_WINDOW_SIZE] == 65535
+        assert s[SettingsFrame.SETTINGS_MAX_FRAME_SIZE] == 16384
+
+    def test_settings_defaults_server(self):
+        """
+        The Settings object begins with the appropriate defaults for servers.
+        """
+        s = h2.settings.Settings(client=False)
+
+        assert s[SettingsFrame.HEADER_TABLE_SIZE] == 4096
+        assert s[SettingsFrame.ENABLE_PUSH] == 0
+        assert s[SettingsFrame.INITIAL_WINDOW_SIZE] == 65535
+        assert s[SettingsFrame.SETTINGS_MAX_FRAME_SIZE] == 16384
+
+    def test_applying_value_doesnt_take_effect_immediately(self):
+        """
+        When a value is applied to the settings object, it doesn't immediately
+        take effect.
+        """
+        s = h2.settings.Settings(client=True)
+        s[SettingsFrame.HEADER_TABLE_SIZE] == 8000
+
+        assert s[SettingsFrame.HEADER_TABLE_SIZE] == 4096
+
+    def test_acknowledging_values(self):
+        """
+        When we acknowledge settings, the values change.
+        """
+        s = h2.settings.Settings(client=True)
+        old_settings = dict(s)
+
+        new_settings = {
+            SettingsFrame.HEADER_TABLE_SIZE: 4000,
+            SettingsFrame.ENABLE_PUSH: 0,
+            SettingsFrame.INITIAL_WINDOW_SIZE: 60,
+            SettingsFrame.SETTINGS_MAX_FRAME_SIZE: 30,
+        }
+        s.update(new_settings)
+
+        assert dict(s) == old_settings
+        s.acknowledge()
+        assert dict(s) == new_settings
+
+    def test_deleting_values_deletes_all_of_them(self):
+        """
+        When we delete a key we lose all state about it.
+        """
+        s = h2.settings.Settings(client=True)
+        s[SettingsFrame.HEADER_TABLE_SIZE] == 8000
+
+        del s[SettingsFrame.HEADER_TABLE_SIZE]
+
+        with pytest.raises(KeyError):
+            s[SettingsFrame.HEADER_TABLE_SIZE]
+
+    def test_length_correctly_reported(self):
+        """
+        Length is related only to the number of keys.
+        """
+        s = h2.settings.Settings(client=True)
+        assert len(s) == 4
+
+        s[SettingsFrame.HEADER_TABLE_SIZE] == 8000
+        assert len(s) == 4
+
+        s.acknowledge()
+        assert len(s) == 4
+
+        del s[SettingsFrame.HEADER_TABLE_SIZE]
+        assert len(s) == 3
+
+    def test_new_values_work(self):
+        """
+        New values initially don't appear
+        """
+        s = h2.settings.Settings(client=True)
+        s[80] = 81
+
+        with pytest.raises(KeyError):
+            s[80]
+
+    def test_new_values_follow_basic_acknowledgement_rules(self):
+        """
+        A new value properly appears when acknowledged.
+        """
+        s = h2.settings.Settings(client=True)
+        s[80] = 81
+        s.acknowledge()
+
+        assert s[80] == 81
+
+    def test_single_values_arent_affected_by_acknowledgement(self):
+        """
+        When acknowledged, unchanged settings remain unchanged.
+        """
+        s = h2.settings.Settings(client=True)
+        assert s[SettingsFrame.HEADER_TABLE_SIZE] == 4096
+
+        s.acknowledge()
+        assert s[SettingsFrame.HEADER_TABLE_SIZE] == 4096


### PR DESCRIPTION
This change introduces a Settings management object to handle adjustments in remote settings. It allows us to keep track of the difference between acknowledged settings and unacknowledged settings, and lets us easily manage the transitions between them.

This is part of #5. It does not add any function for remote settings management: that is yet to come.