### PR TITLE
Enforce settings values.

### DIFF
--- a/h2/connection.py
+++ b/h2/connection.py
@@ -208,13 +208,15 @@ class H2Connection(object):
         self.decoder = Decoder()
         self.client_side = client_side
 
-        # The curent value of the connection flow control window on the
-        # outbound side of the connection.
-        self.outbound_flow_control_window = 65535
-
         # Objects that store settings, including defaults.
         self.local_settings = Settings(client=client_side)
         self.remote_settings = Settings(client=not client_side)
+
+        # The curent value of the connection flow control window on the
+        # outbound side of the connection.
+        self.outbound_flow_control_window = (
+            self.remote_settings.initial_window_size
+        )
 
         # Buffer for incoming data.
         self.incoming_buffer = FrameBuffer(server=not client_side)
@@ -255,7 +257,7 @@ class H2Connection(object):
         s.max_inbound_frame_size = self.max_inbound_frame_size
         s.max_outbound_frame_size = self.max_outbound_frame_size
         s.outbound_flow_control_window = (
-            self.remote_settings[SettingsFrame.INITIAL_WINDOW_SIZE]
+            self.remote_settings.initial_window_size
         )
 
         self.streams[stream_id] = s

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -250,6 +250,34 @@ class H2Connection(object):
         self._data_to_send += b''.join(f.serialize() for f in frames)
         assert all(f.body_len <= self.max_outbound_frame_size for f in frames)
 
+    @property
+    def open_outbound_streams(self):
+        """
+        The current number of open outbound streams.
+        """
+        outbound_numbers = int(self.client_side)
+        return len(
+            [
+                stream_id
+                for stream_id, stream in self.streams.items()
+                if (stream_id % 2 == outbound_numbers) and stream.open
+            ]
+        )
+
+    @property
+    def open_inbound_streams(self):
+        """
+        The current number of open inbound streams.
+        """
+        inbound_numbers = int(not self.client_side)
+        return len(
+            [
+                stream_id
+                for stream_id, stream in self.streams.items()
+                if (stream_id % 2 == inbound_numbers) and stream.open
+            ]
+        )
+
     def begin_new_stream(self, stream_id):
         """
         Initiate a new stream.

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -445,6 +445,12 @@ class H2Connection(object):
                 setting.new_value,
             )
 
+        # HEADER_TABLE_SIZE changes by the remote part affect our encoder: cf.
+        # RFC 7540 Section 6.5.2.
+        if SettingsFrame.HEADER_TABLE_SIZE in changes:
+            setting = changes[SettingsFrame.HEADER_TABLE_SIZE]
+            self.encoder.header_table_size = setting.new_value
+
         f = SettingsFrame(0)
         f.flags.add('ACK')
         self._prepare_for_sending([f])

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -631,6 +631,12 @@ class H2Connection(object):
         """
         Receive a data frame on the connection.
         """
+        if len(frame.data) > self.max_inbound_frame_size:
+            raise ProtocolError(
+                "Frame was too long: length %d, max %d" %
+                (len(frame.data), self.max_inbound_frame_size)
+            )
+
         events = self.state_machine.process_input(
             ConnectionInputs.RECV_DATA
         )

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -203,8 +203,6 @@ class H2Connection(object):
         self.state_machine = H2ConnectionStateMachine()
         self.streams = {}
         self.highest_stream_id = 0
-        self.max_outbound_frame_size = self.DEFAULT_MAX_OUTBOUND_FRAME_SIZE
-        self.max_inbound_frame_size = self.DEFAULT_MAX_INBOUND_FRAME_SIZE
         self.encoder = Encoder()
         self.decoder = Decoder()
         self.client_side = client_side
@@ -218,6 +216,10 @@ class H2Connection(object):
         self.outbound_flow_control_window = (
             self.remote_settings.initial_window_size
         )
+
+        # Maximum frame sizes in each direction.
+        self.max_outbound_frame_size = self.remote_settings.max_frame_size
+        self.max_inbound_frame_size = self.local_settings.max_frame_size
 
         # Buffer for incoming data.
         self.incoming_buffer = FrameBuffer(server=not client_side)

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -246,6 +246,7 @@ class H2Connection(object):
         if not frames:
             return
         self._data_to_send += b''.join(f.serialize() for f in frames)
+        assert all(f.body_len <= self.max_outbound_frame_size for f in frames)
 
     def begin_new_stream(self, stream_id):
         """

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -367,6 +367,9 @@ class H2Connection(object):
         """
         Send a push promise.
         """
+        if not self.remote_settings.enable_push:
+            raise ProtocolError("Remote peer has disabled stream push")
+
         self.state_machine.process_input(ConnectionInputs.SEND_PUSH_PROMISE)
         stream = self.get_stream_by_id(stream_id)
 

--- a/h2/exceptions.py
+++ b/h2/exceptions.py
@@ -27,6 +27,14 @@ class FrameTooLargeError(ProtocolError):
     pass
 
 
+class TooManyStreamsError(ProtocolError):
+    """
+    An attempt was made to open a stream that would lead to too many concurrent
+    streams.
+    """
+    pass
+
+
 class NoSuchStreamError(H2Error):
     """
     A stream-specific action referenced a stream that does not exist.

--- a/h2/exceptions.py
+++ b/h2/exceptions.py
@@ -20,6 +20,13 @@ class ProtocolError(H2Error):
     pass
 
 
+class FrameTooLargeError(ProtocolError):
+    """
+    The frame that we tried to send was too large to be sent.
+    """
+    pass
+
+
 class NoSuchStreamError(H2Error):
     """
     A stream-specific action referenced a stream that does not exist.

--- a/h2/settings.py
+++ b/h2/settings.py
@@ -118,6 +118,17 @@ class Settings(collections.MutableMapping):
     def max_frame_size(self, value):
         self[SettingsFrame.SETTINGS_MAX_FRAME_SIZE] = value
 
+    @property
+    def max_concurrent_streams(self):
+        """
+        The current value of the SETTINGS_MAX_CONCURRENT_STREAMS setting.
+        """
+        return self.get(SettingsFrame.MAX_CONCURRENT_STREAMS, 2**32+1)
+
+    @max_concurrent_streams.setter
+    def max_concurrent_streams(self, value):
+        self[SettingsFrame.MAX_CONCURRENT_STREAMS] = value
+
     # Implement the MutableMapping API.
     def __getitem__(self, key):
         val = self._settings[key][0]

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -383,6 +383,21 @@ class H2Stream(object):
         # side of the stream.
         self.outbound_flow_control_window = 65535
 
+    @property
+    def open(self):
+        """
+        Whether the stream is 'open' in any sense: that is, whether it counts
+        against the number of concurrent streams.
+        """
+        # RFC 7540 Section 5.1.2 defines 'open' for this purpose to mean either
+        # the OPEN state or either of the HALF_CLOSED states. Perplexingly,
+        # this excludes the reserved states.
+        return self.state_machine.state in (
+            StreamState.OPEN,
+            StreamState.HALF_CLOSED_LOCAL,
+            StreamState.HALF_CLOSED_REMOTE,
+        )
+
     def send_headers(self, headers, encoder, end_stream=False):
         """
         Returns a list of HEADERS/CONTINUATION frames to emit as either headers

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -378,7 +378,6 @@ class H2Stream(object):
         self.state_machine = H2StreamStateMachine(stream_id)
         self.stream_id = stream_id
         self.max_outbound_frame_size = None
-        self.max_inbound_frame_size = None
 
         # The curent value of the stream flow control window on the outbound
         # side of the stream.

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -436,21 +436,18 @@ class H2Stream(object):
 
         .. warning:: Does not perform flow control checks.
         """
-        frames = []
-        for offset in range(0, len(data), self.max_outbound_frame_size):
-            self.state_machine.process_input(StreamInputs.SEND_DATA)
-            df = DataFrame(self.stream_id)
-            df.data = data[offset:offset+self.max_outbound_frame_size]
-            frames.append(df)
+        self.state_machine.process_input(StreamInputs.SEND_DATA)
 
+        df = DataFrame(self.stream_id)
+        df.data = data
         if end_stream:
             self.state_machine.process_input(StreamInputs.SEND_END_STREAM)
-            frames[-1].flags.add('END_STREAM')
+            df.flags.add('END_STREAM')
 
         self.outbound_flow_control_window -= len(data)
         assert self.outbound_flow_control_window >= 0
 
-        return frames, []
+        return [df], []
 
     def end_stream(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         'Programming Language :: Python :: Implementation :: CPython',
     ],
     install_requires=[
-        'hyperframe~=2.0',
+        'hyperframe~=2.1',
         'hpack~=1.1.0',
     ],
     extras_require={

--- a/test/test_complex_logic.py
+++ b/test/test_complex_logic.py
@@ -1,0 +1,184 @@
+# -*- coding: utf-8 -*-
+"""
+test_complex_logic
+~~~~~~~~~~~~~~~~
+
+More complex tests that try to do more.
+
+Certain tests don't really eliminate incorrect behaviour unless they do quite
+a bit. These tests should live here, to keep the pain in once place rather than
+hide it in the other parts of the test suite.
+"""
+import h2
+
+
+class TestComplexClient(object):
+    """
+    Complex tests for client-side stacks.
+    """
+    example_request_headers = [
+        (':authority', 'example.com'),
+        (':path', '/'),
+        (':scheme', 'https'),
+        (':method', 'GET'),
+    ]
+    example_response_headers = [
+        (':status', '200'),
+        ('server', 'fake-serv/0.1.0')
+    ]
+
+    def test_correctly_count_server_streams(self, frame_factory):
+        """
+        We correctly count the number of server streams, both inbound and
+        outbound.
+        """
+        # This test makes no sense unless you do both inbound and outbound,
+        # because it's important to confirm that we count them correctly.
+        c = h2.connection.H2Connection(client_side=True)
+        c.initiate_connection()
+        expected_inbound_streams = expected_outbound_streams = 0
+
+        assert c.open_inbound_streams == expected_inbound_streams
+        assert c.open_outbound_streams == expected_outbound_streams
+
+        for stream_id in range(1, 15, 2):
+            # Open an outbound stream
+            c.send_headers(stream_id, self.example_request_headers)
+            expected_outbound_streams += 1
+            assert c.open_inbound_streams == expected_inbound_streams
+            assert c.open_outbound_streams == expected_outbound_streams
+
+            # Receive a pushed stream (to create an inbound one). This doesn't
+            # open until we also receive headers.
+            f = frame_factory.build_push_promise_frame(
+                stream_id=stream_id,
+                promised_stream_id=stream_id+1,
+                headers=self.example_request_headers,
+            )
+            c.receive_data(f.serialize())
+            assert c.open_inbound_streams == expected_inbound_streams
+            assert c.open_outbound_streams == expected_outbound_streams
+
+            f = frame_factory.build_headers_frame(
+                stream_id=stream_id+1,
+                headers=self.example_response_headers,
+            )
+            c.receive_data(f.serialize())
+            expected_inbound_streams += 1
+            assert c.open_inbound_streams == expected_inbound_streams
+            assert c.open_outbound_streams == expected_outbound_streams
+
+        for stream_id in range(13, 0, -2):
+            # Close an outbound stream.
+            c.end_stream(stream_id)
+
+            # Stream doesn't close until both sides close it.
+            assert c.open_inbound_streams == expected_inbound_streams
+            assert c.open_outbound_streams == expected_outbound_streams
+
+            f = frame_factory.build_headers_frame(
+                stream_id=stream_id,
+                headers=self.example_response_headers,
+                flags=['END_STREAM'],
+            )
+            c.receive_data(f.serialize())
+            expected_outbound_streams -= 1
+            assert c.open_inbound_streams == expected_inbound_streams
+            assert c.open_outbound_streams == expected_outbound_streams
+
+            # Pushed streams can only be closed remotely.
+            f = frame_factory.build_headers_frame(
+                stream_id=stream_id+1,
+                headers=self.example_response_headers,
+                flags=['END_STREAM'],
+            )
+            c.receive_data(f.serialize())
+            expected_inbound_streams -= 1
+            assert c.open_inbound_streams == expected_inbound_streams
+            assert c.open_outbound_streams == expected_outbound_streams
+
+        assert c.open_inbound_streams == 0
+        assert c.open_outbound_streams == 0
+
+
+class TestComplexServer(object):
+    """
+    Complex tests for server-side stacks.
+    """
+    example_request_headers = [
+        (':authority', 'example.com'),
+        (':path', '/'),
+        (':scheme', 'https'),
+        (':method', 'GET'),
+    ]
+    example_response_headers = [
+        (':status', '200'),
+        ('server', 'fake-serv/0.1.0')
+    ]
+
+    def test_correctly_count_server_streams(self, frame_factory):
+        """
+        We correctly count the number of server streams, both inbound and
+        outbound.
+        """
+        # This test makes no sense unless you do both inbound and outbound,
+        # because it's important to confirm that we count them correctly.
+        c = h2.connection.H2Connection(client_side=False)
+        c.receive_data(frame_factory.preamble())
+        expected_inbound_streams = expected_outbound_streams = 0
+
+        assert c.open_inbound_streams == expected_inbound_streams
+        assert c.open_outbound_streams == expected_outbound_streams
+
+        for stream_id in range(1, 15, 2):
+            # Receive an inbound stream.
+            f = frame_factory.build_headers_frame(
+                headers=self.example_request_headers,
+                stream_id=stream_id,
+            )
+            c.receive_data(f.serialize())
+            expected_inbound_streams += 1
+            assert c.open_inbound_streams == expected_inbound_streams
+            assert c.open_outbound_streams == expected_outbound_streams
+
+            # Push a stream (to create a outbound one). This doesn't open
+            # until we send our response headers.
+            c.push_stream(stream_id, stream_id+1, self.example_request_headers)
+            assert c.open_inbound_streams == expected_inbound_streams
+            assert c.open_outbound_streams == expected_outbound_streams
+
+            c.send_headers(stream_id+1, self.example_response_headers)
+            expected_outbound_streams += 1
+            assert c.open_inbound_streams == expected_inbound_streams
+            assert c.open_outbound_streams == expected_outbound_streams
+
+        for stream_id in range(13, 0, -2):
+            # Close an inbound stream.
+            f = frame_factory.build_data_frame(
+                data=b'',
+                flags=['END_STREAM'],
+                stream_id=stream_id,
+            )
+            c.receive_data(f.serialize())
+
+            # Stream doesn't close until both sides close it.
+            assert c.open_inbound_streams == expected_inbound_streams
+            assert c.open_outbound_streams == expected_outbound_streams
+
+            c.send_data(stream_id, b'', end_stream=True)
+            expected_inbound_streams -= 1
+            assert c.open_inbound_streams == expected_inbound_streams
+            assert c.open_outbound_streams == expected_outbound_streams
+
+            # Pushed streams, however, we can close ourselves.
+            c.send_data(
+                stream_id=stream_id+1,
+                data=b'',
+                end_stream=True,
+            )
+            expected_outbound_streams -= 1
+            assert c.open_inbound_streams == expected_inbound_streams
+            assert c.open_outbound_streams == expected_outbound_streams
+
+        assert c.open_inbound_streams == 0
+        assert c.open_outbound_streams == 0

--- a/test/test_settings.py
+++ b/test/test_settings.py
@@ -174,6 +174,7 @@ class TestSettings(object):
         assert s.enable_push == s[SettingsFrame.ENABLE_PUSH]
         assert s.initial_window_size == s[SettingsFrame.INITIAL_WINDOW_SIZE]
         assert s.max_frame_size == s[SettingsFrame.SETTINGS_MAX_FRAME_SIZE]
+        assert s.max_concurrent_streams == 2**32 + 1  # A sensible default.
 
     def test_settings_setters(self):
         """
@@ -185,9 +186,11 @@ class TestSettings(object):
         s.enable_push = 1
         s.initial_window_size = 2
         s.max_frame_size = 3
+        s.max_concurrent_streams = 4
 
         s.acknowledge()
         assert s[SettingsFrame.HEADER_TABLE_SIZE] == 0
         assert s[SettingsFrame.ENABLE_PUSH] == 1
         assert s[SettingsFrame.INITIAL_WINDOW_SIZE] == 2
         assert s[SettingsFrame.SETTINGS_MAX_FRAME_SIZE] == 3
+        assert s[SettingsFrame.MAX_CONCURRENT_STREAMS] == 4


### PR DESCRIPTION
This pull request handles the remaining part of #5: settings enforcement. We need to enforce the following settings:

- [x] SETTINGS_HEADER_TABLE_SIZE
- [x] SETTINGS_ENABLE_PUSH
- [x] SETTINGS_MAX_CONCURRENT_STREAMS
- [x] SETTINGS_INITIAL_WINDOW_SIZE
- [x] SETTINGS_MAX_FRAME_SIZE
- [x] SETTINGS_MAX_HEADER_LIST_SIZE

This resolves #5.