### PR TITLE
Add support for sending/receiving trailers.

### DIFF
--- a/h2/connection.py
+++ b/h2/connection.py
@@ -634,13 +634,14 @@ class H2Connection(object):
         """
         Receive a headers frame on the connection.
         """
-        # Check we can open the stream.
-        max_open_streams = self.local_settings.max_concurrent_streams
-        if (self.open_inbound_streams + 1) > max_open_streams:
-            raise TooManyStreamsError(
-                "Max outbound streams is %d, %d open" %
-                (max_open_streams, self.open_outbound_streams)
-            )
+        # If necessary, check we can open the stream.
+        if frame.stream_id not in self.streams:
+            max_open_streams = self.local_settings.max_concurrent_streams
+            if (self.open_inbound_streams + 1) > max_open_streams:
+                raise TooManyStreamsError(
+                    "Max outbound streams is %d, %d open" %
+                    (max_open_streams, self.open_outbound_streams)
+                )
 
         # Let's decode the headers.
         headers = self.decoder.decode(frame.data)

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -342,12 +342,13 @@ class H2Connection(object):
         Send headers on a given stream.
         """
         # Check we can open the stream.
-        max_open_streams = self.remote_settings.max_concurrent_streams
-        if (self.open_outbound_streams + 1) > max_open_streams:
-            raise TooManyStreamsError(
-                "Max outbound streams is %d, %d open" %
-                (max_open_streams, self.open_outbound_streams)
-            )
+        if stream_id not in self.streams:
+            max_open_streams = self.remote_settings.max_concurrent_streams
+            if (self.open_outbound_streams + 1) > max_open_streams:
+                raise TooManyStreamsError(
+                    "Max outbound streams is %d, %d open" %
+                    (max_open_streams, self.open_outbound_streams)
+                )
 
         self.state_machine.process_input(ConnectionInputs.SEND_HEADERS)
         stream = self.get_or_create_stream(stream_id)

--- a/h2/events.py
+++ b/h2/events.py
@@ -34,6 +34,20 @@ class ResponseReceived(object):
         self.headers = None
 
 
+class TrailersReceived(object):
+    """
+    The TrailersReceived event is fired whenever trailers are received on a
+    stream. Trailers are a set of headers sent after the body of the
+    request/response, and are used to provide information that wasn't known
+    ahead of time (e.g. content-length). This event carries the HTTP header
+    fields that form the trailers and the stream ID of the stream on which they
+    were received.
+    """
+    def __init__(self):
+        self.stream_id = None
+        self.headers = None
+
+
 class DataReceived(object):
     """
     The DataReceived event is fired whenever data is received on a stream from

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -243,6 +243,9 @@ class H2StreamStateMachine(object):
                 except ProtocolError:
                     self.state = StreamState.CLOSED
                     raise
+                except AssertionError as e:  # pragma: no cover
+                    self.state = StreamState.CLOSED
+                    raise ProtocolError(e)
 
             return []
 

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -353,9 +353,9 @@ class H2StreamStateMachine(object):
         Fires a PushedStreamReceived event.
         """
         if not self.client:
-            if self.client is None:
+            if self.client is None:  # pragma: no cover
                 msg = "Idle streams cannot receive pushes"
-            else:
+            else:  # pragma: no cover
                 msg = "Cannot receive pushed streams as a server"
             raise ProtocolError(msg)
 

--- a/test/test_basic_logic.py
+++ b/test/test_basic_logic.py
@@ -429,6 +429,58 @@ class TestBasicClient(object):
         with pytest.raises(h2.exceptions.TooManyStreamsError):
             c.send_headers(3, self.example_request_headers)
 
+    def test_can_receive_trailers(self, frame_factory):
+        """
+        When two HEADERS blocks are received in the same stream from a
+        server, the second set are trailers.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_connection()
+        c.send_headers(1, self.example_request_headers)
+        f = frame_factory.build_headers_frame(self.example_response_headers)
+        c.receive_data(f.serialize())
+
+        # Send in trailers.
+        trailers = [('content-length', '0')]
+        f = frame_factory.build_headers_frame(
+            trailers,
+            flags=['END_STREAM'],
+        )
+        events = c.receive_data(f.serialize())
+        assert len(events) == 2
+
+        event = events[0]
+        assert isinstance(event, h2.events.TrailersReceived)
+        assert event.headers == trailers
+        assert event.stream_id == 1
+
+    def test_reject_trailers_not_ending_stream(self, frame_factory):
+        """
+        When trailers are received without the END_STREAM flag being present,
+        this is a ProtocolError.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_connection()
+        c.send_headers(1, self.example_request_headers)
+        f = frame_factory.build_headers_frame(self.example_request_headers)
+        c.receive_data(f.serialize())
+
+        # Send in trailers.
+        c.clear_outbound_data_buffer()
+        trailers = [('content-length', '0')]
+        f = frame_factory.build_headers_frame(
+            trailers,
+            flags=[],
+        )
+
+        with pytest.raises(h2.exceptions.ProtocolError):
+            c.receive_data(f.serialize())
+
+        expected_frame = frame_factory.build_goaway_frame(
+            last_stream_id=1, error_code=h2.errors.PROTOCOL_ERROR,
+        )
+        assert c.data_to_send() == expected_frame.serialize()
+
 
 class TestBasicServer(object):
     """
@@ -976,6 +1028,56 @@ class TestBasicServer(object):
             headers=self.example_request_headers,
         )
         with pytest.raises(h2.exceptions.TooManyStreamsError):
+            c.receive_data(f.serialize())
+
+        expected_frame = frame_factory.build_goaway_frame(
+            last_stream_id=1, error_code=h2.errors.PROTOCOL_ERROR,
+        )
+        assert c.data_to_send() == expected_frame.serialize()
+
+    def test_can_receive_trailers(self, frame_factory):
+        """
+        When two HEADERS blocks are received in the same stream from a
+        client, the second set are trailers.
+        """
+        c = h2.connection.H2Connection(client_side=False)
+        c.receive_data(frame_factory.preamble())
+        f = frame_factory.build_headers_frame(self.example_request_headers)
+        c.receive_data(f.serialize())
+
+        # Send in trailers.
+        trailers = [('content-length', '0')]
+        f = frame_factory.build_headers_frame(
+            trailers,
+            flags=['END_STREAM'],
+        )
+        events = c.receive_data(f.serialize())
+        assert len(events) == 2
+
+        event = events[0]
+        assert isinstance(event, h2.events.TrailersReceived)
+        assert event.headers == trailers
+        assert event.stream_id == 1
+
+    def test_reject_trailers_not_ending_stream(self, frame_factory):
+        """
+        When trailers are received without the END_STREAM flag being present,
+        this is a ProtocolError.
+        """
+        c = h2.connection.H2Connection(client_side=False)
+        c.receive_data(frame_factory.preamble())
+        f = frame_factory.build_headers_frame(self.example_request_headers)
+        c.receive_data(f.serialize())
+
+        # Send in trailers.
+        c.clear_outbound_data_buffer()
+        trailers = [('content-length', '0')]
+        f = frame_factory.build_headers_frame(
+            trailers,
+            flags=[],
+        )
+
+        with pytest.raises(h2.exceptions.ProtocolError):
             c.receive_data(f.serialize())
 
         expected_frame = frame_factory.build_goaway_frame(

--- a/test/test_state_machines.py
+++ b/test/test_state_machines.py
@@ -29,7 +29,7 @@ class TestConnectionStateMachine(object):
 
         try:
             c.process_input(input_)
-        except h2.exceptions.ProtocolError:
+        except (h2.exceptions.ProtocolError, AssertionError):
             assert c.state == h2.connection.ConnectionState.CLOSED
         else:
             assert c.state in h2.connection.ConnectionState

--- a/test/test_state_machines.py
+++ b/test/test_state_machines.py
@@ -29,7 +29,7 @@ class TestConnectionStateMachine(object):
 
         try:
             c.process_input(input_)
-        except (h2.exceptions.ProtocolError, AssertionError):
+        except h2.exceptions.ProtocolError:
             assert c.state == h2.connection.ConnectionState.CLOSED
         else:
             assert c.state in h2.connection.ConnectionState


### PR DESCRIPTION
Trailers are such a pain in the ass, but they're part of the spec so here we are. This PR messes with my beautiful state machines in order to allow these terrible abominations.

Resolves #3.