### PR TITLE
Add basic no-op priority implementation.

### DIFF
--- a/test/helpers.py
+++ b/test/helpers.py
@@ -7,7 +7,7 @@ This module contains helpers for the h2 tests.
 """
 from hyperframe.frame import (
     HeadersFrame, DataFrame, SettingsFrame, WindowUpdateFrame, PingFrame,
-    GoAwayFrame, RstStreamFrame, PushPromiseFrame
+    GoAwayFrame, RstStreamFrame, PushPromiseFrame, PriorityFrame
 )
 from hpack.hpack import Encoder
 
@@ -114,4 +114,18 @@ class FrameFactory(object):
         f.promised_stream_id = promised_stream_id
         f.data = self.encoder.encode(headers)
         f.flags = set(flags)
+        return f
+
+    def build_priority_frame(self,
+                             stream_id,
+                             weight,
+                             depends_on=0,
+                             exclusive=False):
+        """
+        Builds a single priority frame.
+        """
+        f = PriorityFrame(stream_id)
+        f.depends_on = depends_on
+        f.stream_weight = weight
+        f.exclusive = exclusive
         return f

--- a/test/test_priority.py
+++ b/test/test_priority.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""
+test_priority
+~~~~~~~~~~~~~
+
+Test the priority logic of Hyper-h2. Currently Hyper-h2 has a no-op logic for
+priority (which is to say, it's ignored), but in future we'll try to do
+something reasonable with it.
+"""
+import h2.connection
+import h2.stream
+
+
+class TestPriority(object):
+    """
+    Basic priority tests.
+    """
+    def test_receiving_priority_does_nothing(self, frame_factory):
+        """
+        Receiving a priority frame does nothing.
+        """
+        c = h2.connection.H2Connection(client_side=False)
+        c.initiate_connection()
+        c.receive_data(frame_factory.preamble())
+        c.clear_outbound_data_buffer()
+
+        f = frame_factory.build_priority_frame(
+            stream_id=1,
+            weight=255,
+        )
+        events = c.receive_data(f.serialize())
+
+        assert not events
+        assert not c.data_to_send()

--- a/test/test_state_machines.py
+++ b/test/test_state_machines.py
@@ -43,6 +43,30 @@ class TestConnectionStateMachine(object):
         with pytest.raises(ValueError):
             c.process_input(1)
 
+    @pytest.mark.parametrize(
+        "state",
+        (
+            s for s in h2.connection.ConnectionState
+            if s != h2.connection.ConnectionState.CLOSED
+        ),
+    )
+    @pytest.mark.parametrize(
+        "input_",
+        [
+            h2.connection.ConnectionInputs.RECV_PRIORITY,
+            h2.connection.ConnectionInputs.SEND_PRIORITY
+        ]
+    )
+    def test_priority_frames_allowed_in_all_states(self, state, input_):
+        """
+        Priority frames can be sent/received in all connection states except
+        closed.
+        """
+        c = h2.connection.H2ConnectionStateMachine()
+        c.state = state
+
+        c.process_input(input_)
+
 
 class TestStreamStateMachine(object):
     """
@@ -90,3 +114,20 @@ class TestStreamStateMachine(object):
 
         with pytest.raises(h2.exceptions.ProtocolError):
             s.process_input(h2.stream.StreamInputs.SEND_PUSH_PROMISE)
+
+    @pytest.mark.parametrize("state", h2.stream.StreamState)
+    @pytest.mark.parametrize(
+        "input_",
+        [
+            h2.stream.StreamInputs.RECV_PRIORITY,
+            h2.stream.StreamInputs.SEND_PRIORITY
+        ]
+    )
+    def test_priority_frames_allowed_in_all_states(self, state, input_):
+        """
+        Priority frames can be sent/received in all stream states.
+        """
+        c = h2.stream.H2StreamStateMachine(stream_id=1)
+        c.state = state
+
+        c.process_input(input_)


### PR DESCRIPTION
This provides a basic skeleton of a priority implementation. Right now nothing actually *does* anything, because we don't have any support for HTTP/2 priority, but it provides us with the code paths that will need to be extended to add support post 1.0.0.

See also #14.