### PR TITLE
Allow sending GOAWAY frames in the closed state

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,14 @@
 Release History
 ===============
 
+dev
+---
+
+*Bugfixes*
+
+- Do not throw ``ProtocolError``s when attempting to send multiple GOAWAY
+  frames on one connection.
+
 1.0.0 (2015-10-15)
 ------------------
 

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -169,6 +169,12 @@ class H2ConnectionStateMachine(object):
             (None, ConnectionState.SERVER_OPEN),
         (ConnectionState.SERVER_OPEN, ConnectionInputs.RECV_RST_STREAM):
             (None, ConnectionState.SERVER_OPEN),
+
+        # State: closed
+        (ConnectionState.CLOSED, ConnectionInputs.SEND_GOAWAY):
+            (None, ConnectionState.CLOSED),
+        (ConnectionState.CLOSED, ConnectionInputs.RECV_GOAWAY):
+            (None, ConnectionState.CLOSED),
     }
 
     def __init__(self):

--- a/test/test_basic_logic.py
+++ b/test/test_basic_logic.py
@@ -1099,3 +1099,19 @@ class TestBasicServer(object):
         events = c.receive_data(f.serialize())
         assert not events
         assert not c.data_to_send()
+
+    def test_can_send_goaway_repeatedly(self, frame_factory):
+        """
+        We can send a GOAWAY frame as many times as we like.
+        """
+        c = h2.connection.H2Connection(client_side=False)
+        c.receive_data(frame_factory.preamble())
+        c.clear_outbound_data_buffer()
+
+        c.close_connection()
+        c.close_connection()
+        c.close_connection()
+
+        f = frame_factory.build_goaway_frame(last_stream_id=0)
+
+        assert c.data_to_send() == (f.serialize() * 3)


### PR DESCRIPTION
Resolves #36.