### PR TITLE
Stop forcefully changing the decoder table size.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ dev
 
 - Do not throw ``ProtocolError``s when attempting to send multiple GOAWAY
   frames on one connection.
+- We no longer forcefully change the decoder table size when settings changes
+  are ACKed, instead waiting for remote acknowledgement of the change.
 
 1.0.0 (2015-10-15)
 ------------------

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -868,12 +868,6 @@ class H2Connection(object):
         """
         changes = self.local_settings.acknowledge()
 
-        # HEADER_TABLE_SIZE changes by us affect our decoder: cf.
-        # RFC 7540 Section 6.5.2.
-        if SettingsFrame.HEADER_TABLE_SIZE in changes:
-            setting = changes[SettingsFrame.HEADER_TABLE_SIZE]
-            self.decoder.header_table_size = setting.new_value
-
         if SettingsFrame.INITIAL_WINDOW_SIZE in changes:
             setting = changes[SettingsFrame.INITIAL_WINDOW_SIZE]
             self._inbound_flow_control_change_from_settings(

--- a/test/test_basic_logic.py
+++ b/test/test_basic_logic.py
@@ -901,7 +901,9 @@ class TestBasicServer(object):
     def test_settings_local_change_header_table_size(self, frame_factory):
         """
         The remote peer acknowledging a local HEADER_TABLE_SIZE settings change
-        causes us to change the header table size of our decoder.
+        does not cause us to change the header table size of our decoder.
+
+        For an explanation of why this test is this way around, see issue #37.
         """
         c = h2.connection.H2Connection(client_side=False)
         c.receive_data(frame_factory.preamble())
@@ -915,7 +917,7 @@ class TestBasicServer(object):
         c.receive_data(expected_frame.serialize())
         c.clear_outbound_data_buffer()
 
-        assert c.decoder.header_table_size == 80
+        assert c.decoder.header_table_size == 4096
 
     def test_restricting_outbound_frame_size_by_settings(self, frame_factory):
         """


### PR DESCRIPTION
Resolves #37.