### PR TITLE
Improve performance of checking if stream is open

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,6 +17,7 @@ Bugfixes
   frames on one connection.
 - We no longer forcefully change the decoder table size when settings changes
   are ACKed, instead waiting for remote acknowledgement of the change.
+- Improve the performance of checking whether a stream is open.
 
 1.0.0 (2015-10-15)
 ------------------


### PR DESCRIPTION
This turns out to be our major bottleneck during the h2load test, so making this faster is better. This relatively simple change improves the performance of the CPython version of this code by 3x.

The next step is to see whether we can reduce the number of these checks we have to do by expiring old streams.