### PR TITLE
Don't sit on old stream state forever.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,9 @@ API Changes (Backward-Compatible)
 - Added a subclass of ``NoSuchStreamError``, called ``StreamClosedError``, that
   fires when actions are taken on a stream that is closed and has had its state
   flushed from the system.
+- Added ``StreamIDTooLowError``, raised when the user or the remote peer
+  attempts to create a stream with an ID lower than one previously used in the
+  dialog. Inherits from ``ValueError`` for backward-compatibility reasons.
 
 Bugfixes
 ~~~~~~~~
@@ -21,6 +24,8 @@ Bugfixes
 - We no longer forcefully change the decoder table size when settings changes
   are ACKed, instead waiting for remote acknowledgement of the change.
 - Improve the performance of checking whether a stream is open.
+- We now attempt to lazily garbage collect closed streams, to avoid having the
+  state hang around indefinitely, leaking memory.
 
 1.0.0 (2015-10-15)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,9 @@ API Changes (Backward-Compatible)
 
 - Added a new ``ConnectionTerminated`` event, which fires when GOAWAY frames
   are received.
+- Added a subclass of ``NoSuchStreamError``, called ``StreamClosedError``, that
+  fires when actions are taken on a stream that is closed and has had its state
+  flushed from the system.
 
 Bugfixes
 ~~~~~~~~

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -61,6 +61,9 @@ Exceptions
 .. autoclass:: h2.exceptions.NoSuchStreamError
    :members:
 
+.. autoclas:: h2.exceptions.StreamClosedError
+   :members:
+
 
 Protocol Errors
 ~~~~~~~~~~~~~~~

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -80,6 +80,9 @@ Protocol Errors
 .. autoclass:: h2.exceptions.FlowControlError
    :members:
 
+.. autoclass:: h2.exceptions.StreamIDTooLowError
+   :members:
+
 
 HTTP/2 Error Codes
 ------------------

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -856,8 +856,14 @@ class H2Connection(object):
         events = self.state_machine.process_input(
             ConnectionInputs.RECV_RST_STREAM
         )
-        stream = self.get_stream_by_id(frame.stream_id)
-        stream_frames, stream_events = stream.stream_reset(frame)
+        try:
+            stream = self.get_stream_by_id(frame.stream_id)
+        except NoSuchStreamError:
+            # The stream is missing. That's ok, we just do nothing here.
+            stream_frames = []
+            stream_events = []
+        else:
+            stream_frames, stream_events = stream.stream_reset(frame)
 
         return stream_frames, events + stream_events
 

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -19,7 +19,7 @@ from .events import (
 )
 from .exceptions import (
     ProtocolError, NoSuchStreamError, FlowControlError, FrameTooLargeError,
-    TooManyStreamsError, StreamClosedError
+    TooManyStreamsError, StreamClosedError, StreamIDTooLowError
 )
 from .frame_buffer import FrameBuffer
 from .settings import Settings
@@ -318,7 +318,7 @@ class H2Connection(object):
         Initiate a new stream.
         """
         if stream_id <= self.highest_stream_id:
-            raise ValueError(
+            raise StreamIDTooLowError(
                 "Stream ID must be larger than %s", self.highest_stream_id
             )
 

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -703,6 +703,15 @@ class H2Connection(object):
             self.state_machine.process_input(ConnectionInputs.SEND_GOAWAY)
             self._prepare_for_sending([f])
             raise
+        except StreamClosedError as e:
+            # We need to send a RST_STREAM frame on behalf of the stream.
+            # The frame the stream wants to emit is already present in the
+            # exception.
+            # This does not require re-raising: it's an expected behaviour.
+            f = RstStreamFrame(e.stream_id)
+            f.error_code = e.error_code
+            self._prepare_for_sending([f])
+            events = []
         else:
             self._prepare_for_sending(frames)
 

--- a/h2/exceptions.py
+++ b/h2/exceptions.py
@@ -46,6 +46,28 @@ class FlowControlError(ProtocolError):
     error_code = h2.errors.FLOW_CONTROL_ERROR
 
 
+class StreamIDTooLowError(ProtocolError, ValueError):
+    """
+    An attempt was made to open a stream that had an ID that is lower than the
+    highest ID we have seen on this connection.
+
+    For backwards-compatibility reasons, this is also a subclass of
+    ``ValueError``.
+    """
+    # TODO: Remove inheritance from ValueError.
+    def __init__(self, stream_id, max_stream_id):
+        #: The ID of the stream that we attempted to open.
+        self.stream_id = stream_id
+
+        #: The current highest-seen stream ID.
+        self.max_stream_id = max_stream_id
+
+    def __str__(self):
+        return "StreamIDTooLowError: %d is lower than %d" % (
+            self.stream_id, self.max_stream_id
+        )
+
+
 class NoSuchStreamError(H2Error):
     """
     A stream-specific action referenced a stream that does not exist.

--- a/h2/exceptions.py
+++ b/h2/exceptions.py
@@ -53,3 +53,18 @@ class NoSuchStreamError(H2Error):
     def __init__(self, stream_id):
         #: The stream ID that corresponds to the non-existent stream.
         self.stream_id = stream_id
+
+
+class StreamClosedError(NoSuchStreamError):
+    """
+    A more specific form of
+    :class:`NoSuchStreamError <h2.exceptions.NoSuchStreamError>`. Indicates
+    that the stream has since been closed, and that all state relating to that
+    stream has been removed.
+    """
+    def __init__(self, stream_id):
+        #: The stream ID that corresponds to the nonexistent stream.
+        self.stream_id = stream_id
+
+        #: The relevant HTTP/2 error code.
+        self.error_code = h2.errors.STREAM_CLOSED

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -463,6 +463,13 @@ class H2Stream(object):
         # see the comment on ``STREAM_OPEN`` at the top of the file.
         return STREAM_OPEN[self.state_machine.state]
 
+    @property
+    def closed(self):
+        """
+        Whether the stream is closed.
+        """
+        return self.state_machine.state == StreamState.CLOSED
+
     def send_headers(self, headers, encoder, end_stream=False):
         """
         Returns a list of HEADERS/CONTINUATION frames to emit as either headers

--- a/test/test_basic_logic.py
+++ b/test/test_basic_logic.py
@@ -737,6 +737,11 @@ class TestBasicServer(object):
 
         assert e.value.stream_id == 1
 
+        with pytest.raises(h2.exceptions.NoSuchStreamError) as e:
+            c.reset_stream(stream_id=5)
+
+        assert e.value.stream_id == 5
+
     def test_basic_sending_ping_frame_logic(self, frame_factory):
         """
         Sending ping frames serializes a ping frame on stream 0 with

--- a/test/test_closed_streams.py
+++ b/test/test_closed_streams.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+"""
+test_closed_streams
+~~~~~~~~~~~~~~~~~~~
+
+Tests that we handle closed streams correctly.
+"""
+import pytest
+
+import h2.connection
+import h2.errors
+import h2.events
+import h2.exceptions
+
+
+class TestClosedStreams(object):
+    example_request_headers = [
+        (':authority', 'example.com'),
+        (':path', '/'),
+        (':scheme', 'https'),
+        (':method', 'GET'),
+    ]
+
+    def test_can_receive_multiple_rst_stream_frames(self, frame_factory):
+        """
+        Multiple RST_STREAM frames can be received, either at once or well
+        after one another. Only the first fires an event.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_connection()
+        c.send_headers(1, self.example_request_headers, end_stream=True)
+
+        f = frame_factory.build_rst_stream_frame(stream_id=1)
+        events = c.receive_data(f.serialize() * 3)
+        events += c.receive_data(f.serialize() * 3)
+
+        assert len(events) == 1
+        event = events[0]
+
+        assert isinstance(event, h2.events.StreamReset)
+
+    def test_closed_stream_resets_further_frames(self, frame_factory):
+        """
+        A stream that is closed can receive further frames: it simply sends
+        RST_STREAM for it.
+        """
+        c = h2.connection.H2Connection(client_side=False)
+        c.receive_data(frame_factory.preamble())
+        c.initiate_connection()
+
+        f = frame_factory.build_headers_frame(self.example_request_headers)
+        c.receive_data(f.serialize())
+        c.reset_stream(1)
+        c.clear_outbound_data_buffer()
+
+        f = frame_factory.build_data_frame(b'hi there')
+        events = c.receive_data(f.serialize())
+
+        f = frame_factory.build_rst_stream_frame(1, h2.errors.STREAM_CLOSED)
+        assert not events
+        assert c.data_to_send() == f.serialize()
+
+        events = c.receive_data(f.serialize() * 3)
+        assert not events
+        assert c.data_to_send() == f.serialize() * 3
+
+    def test_receiving_low_stream_id_causes_goaway(self, frame_factory):
+        """
+        The remote peer creating a stream with a lower ID than one we've seen
+        causes a GOAWAY frame.
+        """
+        c = h2.connection.H2Connection(client_side=False)
+        c.receive_data(frame_factory.preamble())
+        c.initiate_connection()
+
+        f = frame_factory.build_headers_frame(
+            self.example_request_headers,
+            stream_id=3,
+        )
+        c.receive_data(f.serialize())
+        c.clear_outbound_data_buffer()
+
+        f = frame_factory.build_headers_frame(
+            self.example_request_headers,
+            stream_id=1,
+        )
+
+        with pytest.raises(h2.exceptions.ProtocolError):
+            c.receive_data(f.serialize())
+
+        f = frame_factory.build_goaway_frame(
+            last_stream_id=3,
+            error_code=h2.errors.PROTOCOL_ERROR,
+        )
+        assert c.data_to_send() == f.serialize()

--- a/test/test_closed_streams.py
+++ b/test/test_closed_streams.py
@@ -58,24 +58,26 @@ class TestClosedStreams(object):
         c.reset_stream(1)
         c.clear_outbound_data_buffer()
 
-        f = frame_factory.build_data_frame(b'hi there')
-        events = c.receive_data(f.serialize())
+        data_frame = frame_factory.build_data_frame(b'hi there')
+        events = c.receive_data(data_frame.serialize())
 
-        f = frame_factory.build_rst_stream_frame(1, h2.errors.STREAM_CLOSED)
+        rst_frame = frame_factory.build_rst_stream_frame(
+            1, h2.errors.STREAM_CLOSED
+        )
         assert not events
-        assert c.data_to_send() == f.serialize()
+        assert c.data_to_send() == rst_frame.serialize()
 
-        events = c.receive_data(f.serialize() * 3)
+        events = c.receive_data(data_frame.serialize() * 3)
         assert not events
-        assert c.data_to_send() == f.serialize() * 3
+        assert c.data_to_send() == rst_frame.serialize() * 3
 
         # Iterate over the streams to make sure it's gone, then confirm the
         # behaviour is unchanged.
         c.open_outbound_streams
 
-        events = c.receive_data(f.serialize() * 3)
+        events = c.receive_data(data_frame.serialize() * 3)
         assert not events
-        assert c.data_to_send() == f.serialize() * 3
+        assert c.data_to_send() == rst_frame.serialize() * 3
 
     def test_receiving_low_stream_id_causes_goaway(self, frame_factory):
         """

--- a/test/test_closed_streams.py
+++ b/test/test_closed_streams.py
@@ -32,6 +32,11 @@ class TestClosedStreams(object):
 
         f = frame_factory.build_rst_stream_frame(stream_id=1)
         events = c.receive_data(f.serialize() * 3)
+
+        # Force an iteration over all the streams to remove them.
+        c.open_outbound_streams
+
+        # Receive more data.
         events += c.receive_data(f.serialize() * 3)
 
         assert len(events) == 1
@@ -59,6 +64,14 @@ class TestClosedStreams(object):
         f = frame_factory.build_rst_stream_frame(1, h2.errors.STREAM_CLOSED)
         assert not events
         assert c.data_to_send() == f.serialize()
+
+        events = c.receive_data(f.serialize() * 3)
+        assert not events
+        assert c.data_to_send() == f.serialize() * 3
+
+        # Iterate over the streams to make sure it's gone, then confirm the
+        # behaviour is unchanged.
+        c.open_outbound_streams
 
         events = c.receive_data(f.serialize() * 3)
         assert not events

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+"""
+test_exceptions
+~~~~~~~~~~~~~~~
+
+Tests that verify logic local to exceptions.
+"""
+import h2.exceptions
+
+
+class TestExceptions(object):
+    def test_stream_id_too_low_prints_properly(self):
+        x = h2.exceptions.StreamIDTooLowError(5, 10)
+
+        assert "StreamIDTooLowError: 5 is lower than 10" == str(x)

--- a/test/test_state_machines.py
+++ b/test/test_state_machines.py
@@ -82,6 +82,11 @@ class TestStreamStateMachine(object):
             s.process_input(input_)
         except h2.exceptions.ProtocolError:
             assert s.state == h2.stream.StreamState.CLOSED
+        except h2.exceptions.StreamClosedError:
+            # This can only happen for streams that started in the closed
+            # state.
+            assert s.state == h2.stream.StreamState.CLOSED
+            assert state == h2.stream.StreamState.CLOSED
         else:
             assert s.state in h2.stream.StreamState
 


### PR DESCRIPTION
Resolves #48.

This is another performance optimisation from #40. One of the things that was slowing us down was that we'd keep hold of all the state for streams that were long since closed, and would then iterate over it all trying to find out how many streams were open. This change removes that by ensuring that the vast majority of streams are relatively quickly, albeit lazily, removed from the stream state.

This provides about a 10% performance bump on CPython and PyPy (including the changes from #47), which is nice, but it also provides a full order-of-magnitude reduction in the amount of RAM allocated, from GBs to hundreds of MBs. That's enormously important if we plan to actually scale up. This is therefore a big win.