### PR TITLE
Hoist stream state transitions up to module scope

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -26,6 +26,8 @@ Bugfixes
 - Improve the performance of checking whether a stream is open.
 - We now attempt to lazily garbage collect closed streams, to avoid having the
   state hang around indefinitely, leaking memory.
+- Avoid further per-stream allocations, leading to substantial performance
+  improvements when many short-lived streams are used.
 
 1.0.0 (2015-10-15)
 ------------------


### PR DESCRIPTION
This is yet another optimisation as part of #40.

The next problem we had was that each stream allocated a massive dictionary of state transitions. This was required because we need to make callbacks in the class instance. However, this required new allocations of memory for each stream *and* was fairly costly, creating and hashing loads of tuples and doing lots of lookups into enums.

This change hoists that dictionary to module scope, and then explicitly passes the `self` parameter when calling the callbacks. This provides a massive performance improvement in our `h2load` test: 2x on both CPython and PyPy. It also provides a solid RAM usage reduction in CPython, further halving the amount of RAM we were using, which is a real win.

For understandability purposes this hurts a little bit, but the performance gain is really hard to pass up.