### PR TITLE
Correctly report priority weight.

### DIFF
--- a/h2/events.py
+++ b/h2/events.py
@@ -208,7 +208,7 @@ class PriorityUpdate(object):
         self.stream_id = None
 
         #: The new stream weight. May be the same as the original stream
-        #: weight.
+        #: weight. An integer between 1 and 256.
         self.weight = None
 
         #: The stream ID this stream now depends on. May be ``0``.

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -690,9 +690,12 @@ class H2Stream(object):
         """
         event = PriorityUpdate()
         event.stream_id = frame.stream_id
-        event.weight = frame.stream_weight
         event.depends_on = frame.depends_on
         event.exclusive = frame.exclusive
+
+        # Weight is an integer between 1 and 256, but the byte only allows
+        # 0 to 255: add one.
+        event.weight = frame.stream_weight + 1
         return [event]
 
     def _build_headers_frames(self,

--- a/test/test_priority.py
+++ b/test/test_priority.py
@@ -43,7 +43,7 @@ class TestPriority(object):
         assert isinstance(event, h2.events.PriorityUpdate)
         assert event.stream_id == 1
         assert event.depends_on == 0
-        assert event.weight == 255
+        assert event.weight == 256
         assert event.exclusive is False
 
     def test_headers_with_priority_info(self, frame_factory):
@@ -60,7 +60,7 @@ class TestPriority(object):
             headers=self.example_request_headers,
             stream_id=3,
             flags=['PRIORITY'],
-            stream_weight=16,
+            stream_weight=15,
             depends_on=1,
             exclusive=True,
         )


### PR DESCRIPTION
Stream weights are an integer value between 1 and 256, but the byte field on the frame can obviously only report values between 0 and 255. This change updates the `PriorityUpdate` event to report the *true* weight of the frame, not the encoded weight.