### PR TITLE
Reject frames with invalid padding.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
     install_requires=[
-        'hyperframe~=2.2',
+        'hyperframe~=3.0',
         'hpack~=2.0',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
     install_requires=[
-        'hyperframe~=3.0',
+        'hyperframe~=3.0,>=3.0.1',
         'hpack~=2.0',
     ],
     extras_require={


### PR DESCRIPTION
This change force-rejects frames with invalid padding, treating them as a connection error of type PROTOCOL_ERROR.

Resolves #73.