### PR TITLE
Reject DATA frames on closed streams.

### DIFF
--- a/h2/stream.py
+++ b/h2/stream.py
@@ -323,6 +323,8 @@ _transitions = {
         (H2StreamStateMachine.request_sent, StreamState.OPEN),
     (StreamState.IDLE, StreamInputs.RECV_HEADERS):
         (H2StreamStateMachine.request_received, StreamState.OPEN),
+    (StreamState.IDLE, StreamInputs.RECV_DATA):
+        (H2StreamStateMachine.send_reset, StreamState.CLOSED),
     (StreamState.IDLE, StreamInputs.SEND_PUSH_PROMISE):
         (H2StreamStateMachine.send_new_pushed_stream,
             StreamState.RESERVED_LOCAL),
@@ -337,6 +339,8 @@ _transitions = {
     # State: reserved local
     (StreamState.RESERVED_LOCAL, StreamInputs.SEND_HEADERS):
         (None, StreamState.HALF_CLOSED_REMOTE),
+    (StreamState.RESERVED_LOCAL, StreamInputs.RECV_DATA):
+        (H2StreamStateMachine.send_reset, StreamState.CLOSED),
     (StreamState.RESERVED_LOCAL, StreamInputs.SEND_WINDOW_UPDATE):
         (None, StreamState.RESERVED_LOCAL),
     (StreamState.RESERVED_LOCAL, StreamInputs.RECV_WINDOW_UPDATE):
@@ -354,6 +358,8 @@ _transitions = {
     (StreamState.RESERVED_REMOTE, StreamInputs.RECV_HEADERS):
         (H2StreamStateMachine.response_received,
             StreamState.HALF_CLOSED_LOCAL),
+    (StreamState.RESERVED_REMOTE, StreamInputs.RECV_DATA):
+        (H2StreamStateMachine.send_reset, StreamState.CLOSED),
     (StreamState.RESERVED_REMOTE, StreamInputs.SEND_WINDOW_UPDATE):
         (None, StreamState.RESERVED_REMOTE),
     (StreamState.RESERVED_REMOTE, StreamInputs.RECV_WINDOW_UPDATE):
@@ -402,6 +408,8 @@ _transitions = {
         (H2StreamStateMachine.response_sent, StreamState.HALF_CLOSED_REMOTE),
     (StreamState.HALF_CLOSED_REMOTE, StreamInputs.SEND_DATA):
         (None, StreamState.HALF_CLOSED_REMOTE),
+    (StreamState.HALF_CLOSED_REMOTE, StreamInputs.RECV_DATA):
+        (H2StreamStateMachine.send_reset, StreamState.CLOSED),
     (StreamState.HALF_CLOSED_REMOTE, StreamInputs.SEND_END_STREAM):
         (None, StreamState.CLOSED),
     (StreamState.HALF_CLOSED_REMOTE, StreamInputs.SEND_WINDOW_UPDATE):

--- a/test/test_state_machines.py
+++ b/test/test_state_machines.py
@@ -84,9 +84,17 @@ class TestStreamStateMachine(object):
             assert s.state == h2.stream.StreamState.CLOSED
         except h2.exceptions.StreamClosedError:
             # This can only happen for streams that started in the closed
-            # state.
-            assert s.state == h2.stream.StreamState.CLOSED
-            assert state == h2.stream.StreamState.CLOSED
+            # state OR where the input was RECV_DATA and the state was not
+            # OPEN or HALF_CLOSED_LOCAL.
+            if input_ != h2.stream.StreamInputs.RECV_DATA:
+                assert s.state == h2.stream.StreamState.CLOSED
+                assert state == h2.stream.StreamState.CLOSED
+            else:
+                assert s.state == h2.stream.StreamState.CLOSED
+                assert state not in (
+                    h2.stream.StreamState.OPEN,
+                    h2.stream.StreamState.HALF_CLOSED_LOCAL,
+                )
         else:
             assert s.state in h2.stream.StreamState
 


### PR DESCRIPTION
Strictly, RFC 7540 Section 6.1 requires that we send RST_STREAM(STREAM_CLOSED) if we receive a DATA frame on a stream that is not in the OPEN or HALF_CLOSED_LOCAL states. This change enforces that requirement.

Previously we still mostly did OK: we sent GOAWAY(PROTOCOL_ERROR) instead, which has much the same effect. This is just a bit safer, and keeps the connection up a bit longer, even though it can really only happen if the remote peer's state machine is *totally wrecked*.