### PR TITLE
Reject overlarge frames with FRAME_SIZE_ERROR.

### DIFF
--- a/h2/connection.py
+++ b/h2/connection.py
@@ -711,7 +711,7 @@ class H2Connection(object):
         """
         try:
             if frame.body_len > self.max_inbound_frame_size:
-                raise ProtocolError(
+                raise FrameTooLargeError(
                     "Received overlong frame: length %d, max %d" %
                     (frame.body_len, self.max_inbound_frame_size)
                 )

--- a/h2/exceptions.py
+++ b/h2/exceptions.py
@@ -24,9 +24,10 @@ class ProtocolError(H2Error):
 
 class FrameTooLargeError(ProtocolError):
     """
-    The frame that we tried to send was too large to be sent.
+    The frame that we tried to send or that we received was too large.
     """
-    pass
+    #: This error code that corresponds to this kind of Protocol Error.
+    error_code = h2.errors.FRAME_SIZE_ERROR
 
 
 class TooManyStreamsError(ProtocolError):

--- a/test/test_basic_logic.py
+++ b/test/test_basic_logic.py
@@ -993,7 +993,7 @@ class TestBasicServer(object):
             c.receive_data(data_frame.serialize())
 
         expected_frame = frame_factory.build_goaway_frame(
-            last_stream_id=1, error_code=h2.errors.PROTOCOL_ERROR
+            last_stream_id=1, error_code=h2.errors.FRAME_SIZE_ERROR
         )
         assert c.data_to_send() == expected_frame.serialize()
 


### PR DESCRIPTION
Resolves #81.