### PR TITLE
fix exception args

### DIFF
--- a/h2/connection.py
+++ b/h2/connection.py
@@ -336,9 +336,7 @@ class H2Connection(object):
         )
 
         if stream_id <= highest_stream_id:
-            raise StreamIDTooLowError(
-                "Stream ID must be larger than %s", highest_stream_id
-            )
+            raise StreamIDTooLowError(stream_id, highest_stream_id)
 
         if allowed_ids != AllowedStreamIDs.ANY:
             if (stream_id % 2) != int(allowed_ids):


### PR DESCRIPTION
This fixes the arguments to create a new `StreamIDTooLowError` exception.
I'm not sure how that got past this test: https://github.com/python-hyper/hyper-h2/blob/master/test/test_exceptions.py#L12