### PR TITLE
fix highest stream id check for push promise

### DIFF
--- a/h2/connection.py
+++ b/h2/connection.py
@@ -234,7 +234,7 @@ class H2Connection(object):
     def __init__(self, client_side=True):
         self.state_machine = H2ConnectionStateMachine()
         self.streams = {}
-        self.highest_stream_id = 0
+        self.highest_stream_id = [0, 0] # [server-initiated, client-initiated]
         self.encoder = Encoder()
         self.decoder = Decoder()
         self.client_side = client_side
@@ -328,9 +328,9 @@ class H2Connection(object):
         :param stream_id: The ID of the stream to open.
         :param allowed_ids: What kind of stream ID is allowed.
         """
-        if stream_id <= self.highest_stream_id:
+        if stream_id <= self.highest_stream_id[stream_id % 2]:
             raise StreamIDTooLowError(
-                "Stream ID must be larger than %s", self.highest_stream_id
+                "Stream ID must be larger than %s", self.highest_stream_id[stream_id % 2]
             )
 
         if allowed_ids != AllowedStreamIDs.ANY:
@@ -348,7 +348,7 @@ class H2Connection(object):
         s.inbound_flow_control_window = self.local_settings.initial_window_size
 
         self.streams[stream_id] = s
-        self.highest_stream_id = stream_id
+        self.highest_stream_id[stream_id % 2] = stream_id
         return s
 
     def initiate_connection(self):
@@ -389,7 +389,7 @@ class H2Connection(object):
         try:
             return self.streams[stream_id]
         except KeyError:
-            if stream_id > self.highest_stream_id:
+            if stream_id > self.highest_stream_id[stream_id % 2]:
                 raise NoSuchStreamError(stream_id)
             else:
                 raise StreamClosedError(stream_id)
@@ -531,7 +531,7 @@ class H2Connection(object):
 
         f = GoAwayFrame(0)
         f.error_code = error_code
-        f.last_stream_id = self.highest_stream_id
+        f.last_stream_id = max(self.highest_stream_id)
         self._prepare_for_sending([f])
 
         return []


### PR DESCRIPTION
I think there is a problem with regard to PushPromise and the stream ids. Right now there is a value in `H2Connection` called: `highest_stream_id`. It is used to check if a new stream has a higher id than the previous highest value. As far as I understand the spec, this is only considered for the client and server direction independently.

The spec says:
> The identifier of a newly established stream MUST be numerically
> greater than all streams that the initiating endpoint has opened or
> reserved.

This PR is a rough fix, not sure if we get other problems - I'm welcome for alternatives or cleaner solutions. I'm not sure if this fixes everything, as I did not yet get PushPromises working in my code base.