### PR TITLE
Add get_next_available_stream_id function.

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -89,6 +89,9 @@ Protocol Errors
 .. autoclass:: h2.exceptions.InvalidSettingsValueError
    :members:
 
+.. autoclass:: h2.exceptions.NoAvailableStreamIDError
+   :members:
+
 
 HTTP/2 Error Codes
 ------------------

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -59,12 +59,15 @@ Exceptions
 ----------
 
 .. autoclass:: h2.exceptions.H2Error
+   :show-inheritance:
    :members:
 
 .. autoclass:: h2.exceptions.NoSuchStreamError
+   :show-inheritance:
    :members:
 
 .. autoclass:: h2.exceptions.StreamClosedError
+   :show-inheritance:
    :members:
 
 
@@ -72,24 +75,31 @@ Protocol Errors
 ~~~~~~~~~~~~~~~
 
 .. autoclass:: h2.exceptions.ProtocolError
+   :show-inheritance:
    :members:
 
 .. autoclass:: h2.exceptions.FrameTooLargeError
+   :show-inheritance:
    :members:
 
 .. autoclass:: h2.exceptions.TooManyStreamsError
+   :show-inheritance:
    :members:
 
 .. autoclass:: h2.exceptions.FlowControlError
+   :show-inheritance:
    :members:
 
 .. autoclass:: h2.exceptions.StreamIDTooLowError
+   :show-inheritance:
    :members:
 
 .. autoclass:: h2.exceptions.InvalidSettingsValueError
+   :show-inheritance:
    :members:
 
 .. autoclass:: h2.exceptions.NoAvailableStreamIDError
+   :show-inheritance:
    :members:
 
 

--- a/h2/exceptions.py
+++ b/h2/exceptions.py
@@ -69,6 +69,14 @@ class StreamIDTooLowError(ProtocolError, ValueError):
         )
 
 
+class NoAvailableStreamIDError(ProtocolError, ValueError):
+    """
+    There are no available stream IDs left to the connection. All stream IDs
+    have been exhausted.
+    """
+    pass
+
+
 class NoSuchStreamError(H2Error):
     """
     A stream-specific action referenced a stream that does not exist.

--- a/test/test_utility_functions.py
+++ b/test/test_utility_functions.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+"""
+test_utility_functions
+~~~~~~~~~~~~~~~~~~~~~~
+
+Tests for the various utility functions provided by hyper-h2.
+"""
+import pytest
+
+import h2.connection
+import h2.errors
+import h2.events
+import h2.exceptions
+
+# These tests require a non-list-returning range function.
+try:
+    range = xrange
+except NameError:
+    range = range
+
+
+class TestGetNextAvailableStreamID(object):
+    """
+    Tests for the ``H2Connection.get_next_available_stream_id`` method.
+    """
+    example_request_headers = [
+        (':authority', 'example.com'),
+        (':path', '/'),
+        (':scheme', 'https'),
+        (':method', 'GET'),
+    ]
+    example_response_headers = [
+        (':status', '200'),
+        ('server', 'fake-serv/0.1.0')
+    ]
+
+    def test_returns_correct_sequence_for_clients(self, frame_factory):
+        """
+        For a client connection, the correct sequence of stream IDs is
+        returned.
+        """
+        # Running the exhaustive version of this test (all 1 billion available
+        # stream IDs) is too painful. For that reason, we validate that the
+        # original sequence is right for the first few thousand, and then just
+        # check that it terminates properly.
+        #
+        # Make sure that the streams get cleaned up: 8k streams floating
+        # around would make this test memory-hard, and it's not supposed to be
+        # a test of how much RAM your machine has.
+        c = h2.connection.H2Connection(client_side=True)
+        c.initiate_connection()
+        initial_sequence = range(1, 2**13, 2)
+
+        for expected_stream_id in initial_sequence:
+            stream_id = c.get_next_available_stream_id()
+            assert stream_id == expected_stream_id
+
+            c.send_headers(
+                stream_id=stream_id,
+                headers=self.example_request_headers,
+                end_stream=True
+            )
+            f = frame_factory.build_headers_frame(
+                headers=self.example_response_headers,
+                stream_id=stream_id,
+                flags=['END_STREAM'],
+            )
+            c.receive_data(f.serialize())
+            c.clear_outbound_data_buffer()
+
+        # Jump up to the last available stream ID. Don't clean up the stream
+        # here because who cares about one stream.
+        last_client_id = 2**31 - 1
+        c.send_headers(
+            stream_id=last_client_id,
+            headers=self.example_request_headers,
+            end_stream=True
+        )
+
+        with pytest.raises(h2.exceptions.NoAvailableStreamIDError):
+            c.get_next_available_stream_id()
+
+    def test_returns_correct_sequence_for_servers(self, frame_factory):
+        """
+        For a server connection, the correct sequence of stream IDs is
+        returned.
+        """
+        # Running the exhaustive version of this test (all 1 billion available
+        # stream IDs) is too painful. For that reason, we validate that the
+        # original sequence is right for the first few thousand, and then just
+        # check that it terminates properly.
+        #
+        # Make sure that the streams get cleaned up: 8k streams floating
+        # around would make this test memory-hard, and it's not supposed to be
+        # a test of how much RAM your machine has.
+        c = h2.connection.H2Connection(client_side=False)
+        c.initiate_connection()
+        c.receive_data(frame_factory.preamble())
+        f = frame_factory.build_headers_frame(
+            headers=self.example_request_headers
+        )
+        c.receive_data(f.serialize())
+
+        initial_sequence = range(2, 2**13, 2)
+
+        for expected_stream_id in initial_sequence:
+            stream_id = c.get_next_available_stream_id()
+            assert stream_id == expected_stream_id
+
+            c.push_stream(
+                stream_id=1,
+                promised_stream_id=stream_id,
+                request_headers=self.example_request_headers
+            )
+            c.send_headers(
+                stream_id=stream_id,
+                headers=self.example_response_headers,
+                end_stream=True
+            )
+            c.clear_outbound_data_buffer()
+
+        # Jump up to the last available stream ID. Don't clean up the stream
+        # here because who cares about one stream.
+        last_server_id = 2**31 - 2
+        c.push_stream(
+            stream_id=1,
+            promised_stream_id=last_server_id,
+            request_headers=self.example_request_headers,
+        )
+
+        with pytest.raises(h2.exceptions.NoAvailableStreamIDError):
+            c.get_next_available_stream_id()
+
+    def test_does_not_increment_without_stream_send(self):
+        """
+        If a new stream isn't actually created, the next stream ID doesn't
+        change.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_connection()
+
+        first_stream_id = c.get_next_available_stream_id()
+        second_stream_id = c.get_next_available_stream_id()
+
+        assert first_stream_id == second_stream_id
+
+        c.send_headers(
+            stream_id=first_stream_id,
+            headers=self.example_request_headers
+        )
+
+        third_stream_id = c.get_next_available_stream_id()
+        assert third_stream_id == (first_stream_id + 2)


### PR DESCRIPTION
This function returns the next available stream ID for the given endpoint type, client or server. It makes it moderately easier to write a hyper-h2 server, even though it's not strictly necessary, and it also provides useful information about overly large stream IDs.

Resolves #91.

/cc @Kriechi