### PR TITLE
Report the proper last stream ID in GOAWAY frames.

### DIFF
--- a/h2/connection.py
+++ b/h2/connection.py
@@ -798,13 +798,7 @@ class H2Connection(object):
         GOAWAY frames.
         """
         f = GoAwayFrame(0)
-
-        # TODO: Fix this to properly record the last stream ID we've seen.
-        if self.streams:
-            f.last_stream_id = sorted(self.streams.keys())[-1]
-        else:
-            f.last_stream_id = 0
-
+        f.last_stream_id = self.highest_inbound_stream_id
         f.error_code = error_code
         self.state_machine.process_input(ConnectionInputs.SEND_GOAWAY)
         self._prepare_for_sending([f])

--- a/test/test_basic_logic.py
+++ b/test/test_basic_logic.py
@@ -223,7 +223,7 @@ class TestBasicClient(object):
             c.receive_data(f3.serialize())
 
         expected_frame = frame_factory.build_goaway_frame(
-            1, h2.errors.PROTOCOL_ERROR
+            0, h2.errors.PROTOCOL_ERROR
         )
         assert c.data_to_send() == expected_frame.serialize()
 
@@ -439,7 +439,7 @@ class TestBasicClient(object):
             c.receive_data(f.serialize())
 
         expected_frame = frame_factory.build_goaway_frame(
-            last_stream_id=1, error_code=h2.errors.PROTOCOL_ERROR,
+            last_stream_id=0, error_code=h2.errors.PROTOCOL_ERROR,
         )
         assert c.data_to_send() == expected_frame.serialize()
 


### PR DESCRIPTION
Resolves #76.