### PR TITLE
Fix StreamIDTooLowError exception arguments.

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -13,3 +13,7 @@ In chronological order:
 - Maximilian Hils (@maximilianhils)
 
   - Added asyncio example.
+
+- Thomas Kriechbaumer (@Kriechi)
+
+  - Fixed incorrect arguments being passed to ``StreamIDTooLowError``.

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -340,9 +340,7 @@ class H2Connection(object):
         )
 
         if stream_id <= highest_stream_id:
-            raise StreamIDTooLowError(
-                "Stream ID must be larger than %s", highest_stream_id
-            )
+            raise StreamIDTooLowError(stream_id, highest_stream_id)
 
         if allowed_ids != AllowedStreamIDs.ANY:
             if (stream_id % 2) != int(allowed_ids):

--- a/h2/exceptions.py
+++ b/h2/exceptions.py
@@ -47,7 +47,7 @@ class FlowControlError(ProtocolError):
     error_code = h2.errors.FLOW_CONTROL_ERROR
 
 
-class StreamIDTooLowError(ProtocolError, ValueError):
+class StreamIDTooLowError(ProtocolError):
     """
     An attempt was made to open a stream that had an ID that is lower than the
     highest ID we have seen on this connection.
@@ -69,7 +69,7 @@ class StreamIDTooLowError(ProtocolError, ValueError):
         )
 
 
-class NoAvailableStreamIDError(ProtocolError, ValueError):
+class NoAvailableStreamIDError(ProtocolError):
     """
     There are no available stream IDs left to the connection. All stream IDs
     have been exhausted.

--- a/test/test_basic_logic.py
+++ b/test/test_basic_logic.py
@@ -151,8 +151,11 @@ class TestBasicClient(object):
         c.initiate_connection()
         c.send_headers(3, self.example_request_headers, end_stream=False)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(h2.exceptions.StreamIDTooLowError) as e:
             c.send_headers(1, self.example_request_headers, end_stream=True)
+
+        assert e.value.stream_id == 1
+        assert e.value.max_stream_id == 3
 
     def test_receiving_pushed_stream(self, frame_factory):
         """

--- a/test/test_closed_streams.py
+++ b/test/test_closed_streams.py
@@ -100,8 +100,11 @@ class TestClosedStreams(object):
             stream_id=1,
         )
 
-        with pytest.raises(h2.exceptions.ProtocolError):
+        with pytest.raises(h2.exceptions.StreamIDTooLowError) as e:
             c.receive_data(f.serialize())
+
+        assert e.value.stream_id == 1
+        assert e.value.max_stream_id == 3
 
         f = frame_factory.build_goaway_frame(
             last_stream_id=3,


### PR DESCRIPTION
Supersedes #86.