### PR TITLE
Fully support CONTINUATION frames

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,3 +7,4 @@ show_missing = True
 exclude_lines =
     pragma: no cover
     .*:.* # Python \d.*
+    assert False, "Should not be reachable"

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -23,6 +23,9 @@ API Changes (Breaking)
     - ``begin_new_stream``
     - ``receive_frame``
 
+- Added full support for receiving CONTINUATION frames, including policing
+  logic about when and how they are received.
+
 API Changes (Backward-Compatible)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -40,6 +40,7 @@ API Changes (Backward-Compatible)
   with error code FRAME_SIZE_ERROR, not a generic PROTOCOL_ERROR. This
   condition now also raises a ``FrameTooLargeError``, a new subclass of
   ``ProtocolError``.
+- Made ``NoSuchStreamError`` a subclass of ``ProtocolError``.
 
 Bugfixes
 ~~~~~~~~

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -878,6 +878,7 @@ class H2Connection(object):
         """
         events = []
         self.incoming_buffer.add_data(data)
+        self.incoming_buffer.max_frame_size = self.max_inbound_frame_size
 
         try:
             for frame in self.incoming_buffer:
@@ -903,12 +904,6 @@ class H2Connection(object):
            Removed from the public API.
         """
         try:
-            if frame.body_len > self.max_inbound_frame_size:
-                raise FrameTooLargeError(
-                    "Received overlong frame: length %d, max %d" %
-                    (frame.body_len, self.max_inbound_frame_size)
-                )
-
             # I don't love using __class__ here, maybe reconsider it.
             frames, events = self._frame_dispatch_table[frame.__class__](frame)
         except StreamClosedError as e:

--- a/h2/exceptions.py
+++ b/h2/exceptions.py
@@ -79,9 +79,13 @@ class NoAvailableStreamIDError(ProtocolError):
     pass
 
 
-class NoSuchStreamError(H2Error):
+class NoSuchStreamError(ProtocolError):
     """
     A stream-specific action referenced a stream that does not exist.
+
+    .. versionchanged:: 2.0.0
+       Became a subclass of :class:`ProtocolError
+       <h2.exceptions.ProtocolError>`
     """
     def __init__(self, stream_id):
         #: The stream ID that corresponds to the non-existent stream.

--- a/h2/frame_buffer.py
+++ b/h2/frame_buffer.py
@@ -123,8 +123,8 @@ class FrameBuffer(object):
         # First, check that we have enough data to successfully parse the
         # next frame header. If not, bail. Otherwise, parse it.
         if len(self.data) < 9:
-
             raise StopIteration()
+
         f, length = self._parse_frame_header(self.data)
 
         # Next, check that we have enough length to parse the frame body. If

--- a/h2/frame_buffer.py
+++ b/h2/frame_buffer.py
@@ -43,6 +43,27 @@ class FrameBuffer(object):
 
         self.data += data
 
+    def _parse_frame_header(self, data):
+        """
+        Parses the frame header from the data. Either returns a tuple of
+        (frame, length), or throws an exception. The returned frame may be None
+        if the frame is of unknown type.
+        """
+        try:
+            frame, length = Frame.parse_frame_header(data[:9])
+        except UnknownFrameError as e:
+            # Here we do something a bit odd. We want to consume the frame data
+            # as consistently as possible, but we also don't ever want to yield
+            # None. Instead, we make sure that, if there is no frame, we
+            # recurse into ourselves.
+            length = e.length
+            frame = None
+        except ValueError as e:
+            # The frame header is invalid. This is a ProtocolError
+            raise ProtocolError("Invalid frame header received: %s" % str(e))
+
+        return frame, length
+
     def _validate_frame_length(self, length):
         """
         Confirm that the frame is an appropriate length.
@@ -53,41 +74,11 @@ class FrameBuffer(object):
                 (length, self.max_frame_size)
             )
 
-    # The methods below support the iterator protocol.
-    def __iter__(self):
-        return self
-
-    def next(self):  # Python 2
-        # TODO: This method is a *monster*, and desperately needs refactoring
-        # to be cleaner.
-        if len(self.data) < 9:
-            raise StopIteration()
-
-        try:
-            f, length = Frame.parse_frame_header(self.data[:9])
-        except UnknownFrameError as e:
-            # Here we do something a bit odd. We want to consume the frame data
-            # as consistently as possible, but we also don't ever want to yield
-            # None. Instead, we make sure that, if there is no frame, we
-            # recurse into ourselves.
-            length = e.length
-            f = None
-        except ValueError as e:
-            # The frame header is invalid. This is a ProtocolError
-            raise ProtocolError("Invalid frame header received: %s" % str(e))
-
-        if len(self.data) < length + 9:
-            raise StopIteration()
-
-        self._validate_frame_length(length)
-
-        # Don't try to parse the body if we didn't get a frame we know about:
-        # there's nothing we can do with it anyway.
-        if f is not None:
-            f.parse_body(memoryview(self.data[9:9+length]))
-
-        self.data = self.data[9+length:]
-
+    def _update_header_buffer(self, f):
+        """
+        Updates the internal header buffer. Returns a frame that should replace
+        the current one. May throw exceptions if this frame is invalid.
+        """
         # Check if we're in the middle of a headers block. If we are, this
         # frame *must* be a CONTINUATION frame with the same stream ID as the
         # leading HEADERS frame. Anything else is a ProtocolError. If the frame
@@ -121,6 +112,40 @@ class FrameBuffer(object):
             # act like we didn't receive one.
             self._headers_buffer.append(f)
             f = None
+
+        return f
+
+    # The methods below support the iterator protocol.
+    def __iter__(self):
+        return self
+
+    def next(self):  # Python 2
+        # First, check that we have enough data to successfully parse the
+        # next frame header. If not, bail. Otherwise, parse it.
+        if len(self.data) < 9:
+
+            raise StopIteration()
+        f, length = self._parse_frame_header(self.data)
+
+        # Next, check that we have enough length to parse the frame body. If
+        # not, bail, leaving the frame header data in the buffer for next time.
+        if len(self.data) < length + 9:
+            raise StopIteration()
+
+        # Confirm the frame has an appropriate length.
+        self._validate_frame_length(length)
+
+        # Don't try to parse the body if we didn't get a frame we know about:
+        # there's nothing we can do with it anyway.
+        if f is not None:
+            f.parse_body(memoryview(self.data[9:9+length]))
+
+        # At this point, as we know we'll use or discard the entire frame, we
+        # can update the data.
+        self.data = self.data[9+length:]
+
+        # Pass the frame through the header buffer.
+        f = self._update_header_buffer(f)
 
         # If we got a frame we didn't understand or shouldn't yield, rather
         # than return None it'd be better if we just tried to get the next

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -407,7 +407,7 @@ _transitions = {
     (StreamState.HALF_CLOSED_REMOTE, StreamInputs.SEND_HEADERS):
         (H2StreamStateMachine.response_sent, StreamState.HALF_CLOSED_REMOTE),
     (StreamState.HALF_CLOSED_REMOTE, StreamInputs.RECV_HEADERS):
-        (H2StreamStateMachine.stream_reset, StreamState.CLOSED),
+        (H2StreamStateMachine.send_reset, StreamState.CLOSED),
     (StreamState.HALF_CLOSED_REMOTE, StreamInputs.SEND_DATA):
         (None, StreamState.HALF_CLOSED_REMOTE),
     (StreamState.HALF_CLOSED_REMOTE, StreamInputs.RECV_DATA):
@@ -426,7 +426,7 @@ _transitions = {
         (H2StreamStateMachine.send_push_promise,
             StreamState.HALF_CLOSED_REMOTE),
     (StreamState.HALF_CLOSED_REMOTE, StreamInputs.RECV_PUSH_PROMISE):
-        (H2StreamStateMachine.stream_reset, StreamState.CLOSED),
+        (H2StreamStateMachine.send_reset, StreamState.CLOSED),
     (StreamState.HALF_CLOSED_REMOTE, StreamInputs.SEND_PRIORITY):
         (None, StreamState.HALF_CLOSED_REMOTE),
     (StreamState.HALF_CLOSED_REMOTE, StreamInputs.RECV_PRIORITY):

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -7,7 +7,8 @@ This module contains helpers for the h2 tests.
 """
 from hyperframe.frame import (
     HeadersFrame, DataFrame, SettingsFrame, WindowUpdateFrame, PingFrame,
-    GoAwayFrame, RstStreamFrame, PushPromiseFrame, PriorityFrame
+    GoAwayFrame, RstStreamFrame, PushPromiseFrame, PriorityFrame,
+    ContinuationFrame
 )
 from hpack.hpack import Encoder
 
@@ -50,6 +51,16 @@ class FrameFactory(object):
 
         for k, v in priority_kwargs.items():
             setattr(f, k, v)
+
+        return f
+
+    def build_continuation_frame(self, header_block, flags=[], stream_id=1):
+        """
+        Builds a single continuation frame out of the binary header block.
+        """
+        f = ContinuationFrame(stream_id)
+        f.data = header_block
+        f.flags = set(flags)
 
         return f
 

--- a/test/test_state_machines.py
+++ b/test/test_state_machines.py
@@ -100,6 +100,7 @@ class TestStreamStateMachine(object):
                     h2.stream.StreamInputs.RECV_HEADERS,
                     h2.stream.StreamInputs.RECV_PUSH_PROMISE,
                     h2.stream.StreamInputs.RECV_DATA,
+                    h2.stream.StreamInputs.RECV_CONTINUATION,
                 )
         else:
             assert s.state in h2.stream.StreamState


### PR DESCRIPTION
This change is a bit of a monster to review, but looking at each commit in isolation should tell the story. In order to get this to work I had to push some of the frame length checking logic into the frame buffer where previously it was in the connection, but that's probably just fine.