### PR TITLE
Fire StreamReset when hyper-h2 forcefully resets a stream due to protocol errors.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -41,6 +41,12 @@ API Changes (Backward-Compatible)
   condition now also raises a ``FrameTooLargeError``, a new subclass of
   ``ProtocolError``.
 - Made ``NoSuchStreamError`` a subclass of ``ProtocolError``.
+- The ``StreamReset`` event is now also fired whenever a protocol error from
+  the remote peer forces a stream to close early. This is only fired once.
+- The ``StreamReset`` event now carries a flag, ``remote_reset``, that is set
+  to ``True`` in all cases where ``StreamReset`` would previously have fired
+  (e.g. when the remote peer sent a RST_STREAM), and is set to ``False`` when
+  it fires because the remote peer made a protocol error.
 
 Bugfixes
 ~~~~~~~~

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -916,7 +916,7 @@ class H2Connection(object):
             f = RstStreamFrame(e.stream_id)
             f.error_code = e.error_code
             self._prepare_for_sending([f])
-            events = []
+            events = e._events
         else:
             self._prepare_for_sending(frames)
 

--- a/h2/events.py
+++ b/h2/events.py
@@ -150,9 +150,13 @@ class StreamEnded(object):
 
 class StreamReset(object):
     """
-    The StreamReset event is fired whenever a stream is forcefully reset by the
-    remote party. When this event is received, no further data can be sent on
-    the stream.
+    The StreamReset event is fired in two situations. The first is when the
+    remote party forcefully resets the stream. The second is when the remote
+    party has made a protocol error which only affects a single stream. In this
+    case, Hyper-h2 will terminate the stream early and return this event.
+
+    .. versionchanged:: 2.0.0
+       This event is now fired when Hyper-h2 automatically resets a stream.
     """
     def __init__(self):
         #: The Stream ID of the stream that was reset.
@@ -160,6 +164,9 @@ class StreamReset(object):
 
         #: The error code given.
         self.error_code = None
+
+        #: Whether the remote peer sent a RST_STREAM or we did.
+        self.remote_reset = True
 
 
 class PushedStreamReceived(object):

--- a/h2/exceptions.py
+++ b/h2/exceptions.py
@@ -106,6 +106,10 @@ class StreamClosedError(NoSuchStreamError):
         #: The relevant HTTP/2 error code.
         self.error_code = h2.errors.STREAM_CLOSED
 
+        # Any events that internal code may need to fire. Not relevant to
+        # external users that may receive a StreamClosedError.
+        self._events = []
+
 
 class InvalidSettingsValueError(ProtocolError, ValueError):
     """

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -97,10 +97,11 @@ class H2StreamStateMachine(object):
                 "Invalid input %s in state %s" % (input_, old_state)
             )
         else:
+            previous_state = self.state
             self.state = target_state
             if func is not None:
                 try:
-                    return func(self)
+                    return func(self, previous_state)
                 except ProtocolError:
                     self.state = StreamState.CLOSED
                     raise
@@ -110,7 +111,7 @@ class H2StreamStateMachine(object):
 
             return []
 
-    def request_sent(self):
+    def request_sent(self, previous_state):
         """
         Fires when a request is sent.
         """
@@ -118,7 +119,7 @@ class H2StreamStateMachine(object):
         self.headers_sent = True
         return []
 
-    def response_sent(self):
+    def response_sent(self, previous_state):
         """
         Fires when something that should be a response is sent. This 'response'
         may actually be trailers.
@@ -133,7 +134,7 @@ class H2StreamStateMachine(object):
 
         return []
 
-    def request_received(self):
+    def request_received(self, previous_state):
         """
         Fires when a request is received.
         """
@@ -147,7 +148,7 @@ class H2StreamStateMachine(object):
         event.stream_id = self.stream_id
         return [event]
 
-    def response_received(self):
+    def response_received(self, previous_state):
         """
         Fires when a response is received. Also disambiguates between responses
         and trailers.
@@ -164,7 +165,7 @@ class H2StreamStateMachine(object):
         event.stream_id = self.stream_id
         return [event]
 
-    def data_received(self):
+    def data_received(self, previous_state):
         """
         Fires when data is received.
         """
@@ -172,7 +173,7 @@ class H2StreamStateMachine(object):
         event.stream_id = self.stream_id
         return [event]
 
-    def window_updated(self):
+    def window_updated(self, previous_state):
         """
         Fires when a window update frame is received.
         """
@@ -180,7 +181,7 @@ class H2StreamStateMachine(object):
         event.stream_id = self.stream_id
         return [event]
 
-    def stream_ended(self):
+    def stream_ended(self, previous_state):
         """
         Fires when a stream is cleanly ended.
         """
@@ -188,7 +189,7 @@ class H2StreamStateMachine(object):
         event.stream_id = self.stream_id
         return [event]
 
-    def stream_reset(self):
+    def stream_reset(self, previous_state):
         """
         Fired when a stream is forcefully reset.
         """
@@ -196,7 +197,7 @@ class H2StreamStateMachine(object):
         event.stream_id = self.stream_id
         return [event]
 
-    def send_new_pushed_stream(self):
+    def send_new_pushed_stream(self, previous_state):
         """
         Fires on the newly pushed stream, when pushed by the local peer.
 
@@ -206,7 +207,7 @@ class H2StreamStateMachine(object):
         self.client = False
         return []
 
-    def recv_new_pushed_stream(self):
+    def recv_new_pushed_stream(self, previous_state):
         """
         Fires on the newly pushed stream, when pushed by the remote peer.
 
@@ -216,7 +217,7 @@ class H2StreamStateMachine(object):
         self.client = True
         return []
 
-    def send_push_promise(self):
+    def send_push_promise(self, previous_state):
         """
         Fires on the already-existing stream when a PUSH_PROMISE frame is sent.
         We may only send PUSH_PROMISE frames if we're a server.
@@ -226,7 +227,7 @@ class H2StreamStateMachine(object):
 
         return []
 
-    def recv_push_promise(self):
+    def recv_push_promise(self, previous_state):
         """
         Fires on the already-existing stream when a PUSH_PROMISE frame is
         received. We may only receive PUSH_PROMISE frames if we're a client.
@@ -244,7 +245,7 @@ class H2StreamStateMachine(object):
         event.parent_stream_id = self.stream_id
         return [event]
 
-    def send_reset(self):
+    def send_reset(self, previous_state):
         """
         Called when we need to forcefully emit another RST_STREAM frame on
         behalf of the state machine.

--- a/test/test_basic_logic.py
+++ b/test/test_basic_logic.py
@@ -329,6 +329,7 @@ class TestBasicClient(object):
         assert isinstance(event, h2.events.StreamReset)
         assert event.stream_id == 1
         assert event.error_code == 5
+        assert event.remote_reset
 
     def test_can_consume_partial_data_from_connection(self):
         """


### PR DESCRIPTION
Resolves #100.