### PR TITLE
Handle frames with bad sizes without letting struct errors leak.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -65,6 +65,7 @@ Bugfixes
   partially handled when terminating connections.
 - Fixed an error in the arguments of ``StreamIDTooLowError``.
 - Prevent ``ValueError``s leaking from Hyperframe.
+- Prevent ``struct.error`` and ``InvalidFrameError`` leaking from Hyperframe.
 
 1.1.1 (2015-11-17)
 ------------------

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -91,6 +91,10 @@ Protocol Errors
    :show-inheritance:
    :members:
 
+.. autoclass:: h2.exceptions.FrameDataMissingError
+   :show-inheritance:
+   :members:
+
 .. autoclass:: h2.exceptions.TooManyStreamsError
    :show-inheritance:
    :members:

--- a/h2/exceptions.py
+++ b/h2/exceptions.py
@@ -30,6 +30,16 @@ class FrameTooLargeError(ProtocolError):
     error_code = h2.errors.FRAME_SIZE_ERROR
 
 
+class FrameDataMissingError(ProtocolError):
+    """
+    The frame that we received is missing some data.
+
+    .. versionadded:: 2.0.0
+    """
+    #: The error code that corresponds to this kind of Protocol Error
+    error_code = h2.errors.FRAME_SIZE_ERROR
+
+
 class TooManyStreamsError(ProtocolError):
     """
     An attempt was made to open a stream that would lead to too many concurrent

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
     install_requires=[
-        'hyperframe~=3.0,>=3.0.1',
+        'hyperframe~=3.1',
         'hpack~=2.0',
     ],
     extras_require={


### PR DESCRIPTION
Resolves #109.