### PR TITLE
Provide the flow controlled length on DataReceived

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,13 @@ Release History
 dev
 ---
 
+API Changes (Backward-Compatible)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Added new field to ``DataReceived``: ``flow_controlled_length``. This is the
+  length of the frame including padded data, allowing users to correctly track
+  changes to the flow control window.
+
 Bugfixes
 ~~~~~~~~
 

--- a/h2/events.py
+++ b/h2/events.py
@@ -70,6 +70,12 @@ class DataReceived(object):
         #: The data itself.
         self.data = None
 
+        #: The amount of data received that counts against the flow control
+        #: window. Note that padding counts against the flow control window, so
+        #: when adjusting flow control you should always use this field rather
+        #: than ``len(data)``.
+        self.flow_controlled_length = None
+
 
 class WindowUpdated(object):
     """

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -738,6 +738,7 @@ class H2Stream(object):
             )
 
         events[0].data = data
+        events[0].flow_controlled_length = flow_control_len
         return [], events
 
     def receive_window_update(self, increment):

--- a/test/test_basic_logic.py
+++ b/test/test_basic_logic.py
@@ -620,6 +620,34 @@ class TestBasicServer(object):
         assert isinstance(event, h2.events.DataReceived)
         assert event.stream_id == 3
         assert event.data == b'some request data'
+        assert event.flow_controlled_length == 17
+
+    def test_data_event_with_padding(self, frame_factory):
+        """
+        Test that data received on a stream fires a DataReceived event that
+        accounts for padding.
+        """
+        c = h2.connection.H2Connection(client_side=False)
+        c.receive_data(frame_factory.preamble())
+
+        f1 = frame_factory.build_headers_frame(
+            self.example_request_headers, stream_id=3
+        )
+        f2 = frame_factory.build_data_frame(
+            b'some request data',
+            stream_id=3,
+            padding_len=20
+        )
+        data = b''.join(map(lambda f: f.serialize(), [f1, f2]))
+        events = c.receive_data(data)
+
+        assert len(events) == 2
+        event = events[1]
+
+        assert isinstance(event, h2.events.DataReceived)
+        assert event.stream_id == 3
+        assert event.data == b'some request data'
+        assert event.flow_controlled_length == 17 + 20 + 1
 
     def test_receiving_ping_frame(self, frame_factory):
         """


### PR DESCRIPTION
This allows users to keep track of what the change is to the flow control window size, without having to expose the padding to them.