### PR TITLE
Don't allow SETTINGS_INITIAL_WINDOW_SIZE to update the connection flow control window.

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -25,3 +25,8 @@ In chronological order:
 - Thomas Kriechbaumer (@Kriechi)
 
   - Fixed incorrect arguments being passed to ``StreamIDTooLowError``.
+
+- WeiZheng Xu (@boyxuper)
+
+  - Reported a bug relating to hyper-h2's updating of the connection window in
+    response to SETTINGS_INITIAL_WINDOW_SIZE.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -16,6 +16,9 @@ Bugfixes
 
 - Hyper-h2 now correctly accounts for padding when maintaining flow control
   windows.
+- Resolved a bug where hyper-h2 would mistakenly apply
+  SETTINGS_INITIAL_WINDOW_SIZE to the connection flow control window in
+  addition to the stream-level flow control windows.
 
 2.0.0 (2016-01-25)
 ------------------

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -849,13 +849,11 @@ class H2Connection(object):
         SETTINGS_INITIAL_WINDOW_SIZE.
 
         When this setting is changed, it automatically updates all flow control
-        windows by the delta in the settings values.
+        windows by the delta in the settings values. Note that it does not
+        increment the *connection* flow control window, per section 6.9.2 of
+        RFC 7540.
         """
         delta = new_value - old_value
-        self.outbound_flow_control_window = guard_increment_window(
-            self.outbound_flow_control_window,
-            delta
-        )
 
         for stream in self.streams.values():
             stream.outbound_flow_control_window = guard_increment_window(
@@ -872,7 +870,6 @@ class H2Connection(object):
         control windows by the delta in the settings values.
         """
         delta = new_value - old_value
-        self.inbound_flow_control_window += delta
 
         for stream in self.streams.values():
             stream.inbound_flow_control_window += delta


### PR DESCRIPTION
Resolves #137.

@boyxuper Thanks so much for reporting this. Please take a quick look at this diff, particularly at CONTRIBUTORS.rst to check that you're happy with how you're being credited. Then feel free to test your code against the `master` branch when this change is merged to confirm that your initial set of problems are resolved.

I'm looking at releasing 2.1.0 sometime early next week.