### PR TITLE
Clarify copyright assignment.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Cory Benfield
+Copyright (c) 2015-2016 Cory Benfield and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Specifically, hyper-h2 contributors do not assign copyright to me, but instead license their code to the project under the MIT license. They retain their copyrights.