### PR TITLE
Throw ProtocolError on invalid content-length headers.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -23,6 +23,9 @@ Bugfixes
 - Resolved a bug where hyper-h2 would mistakenly apply
   SETTINGS_INITIAL_WINDOW_SIZE to the connection flow control window in
   addition to the stream-level flow control windows.
+- Invalid Content-Length headers now throw ``ProtocolError`` exceptions and
+  correctly tear the connection down, instead of leaving the connection in an
+  indeterminate state.
 
 2.0.0 (2016-01-25)
 ------------------

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -856,7 +856,13 @@ class H2Stream(object):
         """
         for n, v in headers:
             if n == 'content-length':
-                self._expected_content_length = int(v, 10)
+                try:
+                    self._expected_content_length = int(v, 10)
+                except ValueError:
+                    raise ProtocolError(
+                        "Invalid content-length header: %s" % v
+                    )
+
                 return
 
     def _track_content_length(self, length, end_stream):

--- a/test/test_invalid_frame_sequences.py
+++ b/test/test_invalid_frame_sequences.py
@@ -366,3 +366,26 @@ class TestInvalidFrameSequences(object):
             error_code=h2.errors.PROTOCOL_ERROR
         )
         assert c.data_to_send() == expected_frame.serialize()
+
+    @pytest.mark.parametrize('value', ['', 'twelve'])
+    def test_error_on_invalid_content_length(self, frame_factory, value):
+        """
+        When an invalid content-length is received, a ProtocolError is thrown.
+        """
+        c = h2.connection.H2Connection(client_side=False)
+        c.initiate_connection()
+        c.receive_data(frame_factory.preamble())
+        c.clear_outbound_data_buffer()
+
+        f = frame_factory.build_headers_frame(
+            stream_id=1,
+            headers=self.example_request_headers + [('content-length', value)]
+        )
+        with pytest.raises(h2.exceptions.ProtocolError):
+            c.receive_data(f.serialize())
+
+        expected_frame = frame_factory.build_goaway_frame(
+            last_stream_id=1,
+            error_code=h2.errors.PROTOCOL_ERROR
+        )
+        assert c.data_to_send() == expected_frame.serialize()


### PR DESCRIPTION
Resolves #141.