### PR TITLE
Specify the extra requirements in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
 [wheel]
 universal = 1
+
+[metadata]
+requires-dist =
+    enum34>=1.0.4,<1.1; python_version<"3.4"

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,4 @@ setup(
         'hyperframe~=3.1',
         'hpack~=2.0',
     ],
-    extras_require={
-        ':python_version<"3.4"': ['enum34~=1.0.4'],
-    }
 )


### PR DESCRIPTION
This allows hyper-h2 to be installed with old versions of pip and
setuptools

Closes #151