### PR TITLE
Support old setuptools versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,10 +57,10 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
     install_requires=[
-        'hyperframe~=3.1',
-        'hpack~=2.0',
+        'hyperframe>=3.1, <4',
+        'hpack>=2.0, <3',
     ],
     extras_require={
-        ':python_version<"3.4"': ['enum34~=1.0.4'],
+        ':python_version == "2.7" or python_version == "3.3"': ['enum34>=1.0.4, <1.1'],
     }
 )


### PR DESCRIPTION
This fixes the installation on Ubuntu 14.04 (but not 12.04). We must neither use `python_version<"3.4"` (that is setuptools 17.1 or so) nor `~=`.