### PR TITLE
GOAWAY additional data in ConnectionTerminated event

### DIFF
--- a/h2/connection.py
+++ b/h2/connection.py
@@ -1167,6 +1167,8 @@ class H2Connection(object):
         new_event = ConnectionTerminated()
         new_event.error_code = frame.error_code
         new_event.last_stream_id = frame.last_stream_id
+        new_event.additional_data = (frame.additional_data
+                                     if frame.additional_data else None)
         events.append(new_event)
 
         return [], events

--- a/h2/events.py
+++ b/h2/events.py
@@ -334,6 +334,9 @@ class ConnectionTerminated(object):
         #: peer and so can safely be resent.
         self.last_stream_id = None
 
+        #: Additional debug data that can be appended to GOAWAY frame.
+        self.additional_data = None
+
     def __repr__(self):
         return "<ConnectionTerminated error_code:%s, last_stream_id:%s>" % (
             self.error_code, self.last_stream_id

--- a/h2/events.py
+++ b/h2/events.py
@@ -338,8 +338,15 @@ class ConnectionTerminated(object):
         self.additional_data = None
 
     def __repr__(self):
-        return "<ConnectionTerminated error_code:%s, last_stream_id:%s>" % (
-            self.error_code, self.last_stream_id
+        return (
+            "<ConnectionTerminated error_code:%s, last_stream_id:%s, "
+            "additional_data:%s>" % (
+                self.error_code,
+                self.last_stream_id,
+                _bytes_representation(
+                    self.additional_data[:20]
+                    if self.additional_data else None)
+            )
         )
 
 
@@ -352,6 +359,9 @@ def _bytes_representation(data):
     mainline of the code. It's safe to use in things like object repr methods
     though.
     """
+    if data is None:
+        return None
+
     hex = binascii.hexlify(data)
 
     # This is moderately clever: on all Python versions hexlify returns a byte

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -109,13 +109,17 @@ class FrameFactory(object):
 
         return f
 
-    def build_goaway_frame(self, last_stream_id, error_code=0):
+    def build_goaway_frame(self,
+                           last_stream_id,
+                           error_code=0,
+                           additional_data=b''):
         """
         Builds a single GOAWAY frame.
         """
         f = GoAwayFrame(0)
         f.error_code = error_code
         f.last_stream_id = last_stream_id
+        f.additional_data = additional_data
         return f
 
     def build_rst_stream_frame(self, stream_id, error_code=0):

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -10,6 +10,7 @@ from hypothesis import given
 from hypothesis.strategies import (
     integers, lists, tuples
 )
+import pytest
 
 import h2.errors
 import h2.events
@@ -267,14 +268,20 @@ class TestEventReprs(object):
             "exclusive:True>"
         )
 
-    def test_connectionterminated_repr(self):
+    @pytest.mark.parametrize("additional_data,data_repr", [
+        (None, "None"),
+        (b'some data', "736f6d652064617461")
+    ])
+    def test_connectionterminated_repr(self, additional_data, data_repr):
         """
         ConnectionTerminated has a useful debug representation.
         """
         e = h2.events.ConnectionTerminated()
         e.error_code = h2.errors.INADEQUATE_SECURITY
         e.last_stream_id = 33
+        e.additional_data = additional_data
 
         assert repr(e) == (
-            "<ConnectionTerminated error_code:12, last_stream_id:33>"
+            "<ConnectionTerminated error_code:12, last_stream_id:33, "
+            "additional_data:%s>" % data_repr
         )


### PR DESCRIPTION
I think, it's handy to have access to additional data. i.e. Apple puts JSON with disconnect reason into GOAWAY frame https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/APNsProviderAPI.html

RFC states
>  Endpoints MAY append opaque data to the payload of any GOAWAY frame.
   Additional debug data is intended for diagnostic purposes only and
   carries no semantic value.  Debug information could contain security-
   or privacy-sensitive data.  Logged or otherwise persistently stored
   debug data MUST have adequate safeguards to prevent unauthorized
   access.

so I didn't add additional_data to `__repr__` 

BTW, thanks for the repo. I really like that it is transport-agnostic