### PR TITLE
Better handle frames on streams we reset.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -20,6 +20,21 @@ Bugfixes
   streams can only be pushed on streams that were initiated by the client.
 - Correctly allow CONTINUATION frames to extend the header block started by a
   PUSH_PROMISE frame.
+- Changed our handling of frames received on streams that were reset by the
+  user.
+
+  Previously these would, at best, cause ProtocolErrors to be raised and the
+  connection to be torn down (rather defeating the point of resetting streams
+  at all) and, at worst, would cause subtle inconsistencies in state between
+  hyper-h2 and the remote peer that could lead to header block decoding errors
+  or flow control blockages.
+
+  Now when the user resets a stream all further frames received on that stream
+  are ignored except where they affect some form of connection-level state,
+  where they have their effect and are then ignored.
+- Fixed a bug whereby receiving a PUSH_PROMISE frame on a stream that was
+  closed would cause a RST_STREAM frame to be emitted on the closed-stream,
+  but not the newly-pushed one. Now this causes a ``ProtocolError``.
 
 2.1.1 (2016-02-05)
 ------------------

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -710,6 +710,7 @@ class H2Connection(object):
         frames = stream.reset_stream(error_code)
         self._prepare_for_sending(frames)
         self._reset_streams.add(stream_id)
+        del self.streams[stream_id]
 
     def close_connection(self, error_code=0):
         """

--- a/test/test_closed_streams.py
+++ b/test/test_closed_streams.py
@@ -20,6 +20,10 @@ class TestClosedStreams(object):
         (':scheme', 'https'),
         (':method', 'GET'),
     ]
+    example_response_headers = [
+        (':status', '200'),
+        ('server', 'fake-serv/0.1.0')
+    ]
 
     def test_can_receive_multiple_rst_stream_frames(self, frame_factory):
         """
@@ -53,9 +57,15 @@ class TestClosedStreams(object):
         c.receive_data(frame_factory.preamble())
         c.initiate_connection()
 
-        f = frame_factory.build_headers_frame(self.example_request_headers)
+        f = frame_factory.build_headers_frame(
+            self.example_request_headers, flags=['END_STREAM']
+        )
         c.receive_data(f.serialize())
-        c.reset_stream(1)
+        c.send_headers(
+            stream_id=1,
+            headers=self.example_response_headers,
+            end_stream=True
+        )
         c.clear_outbound_data_buffer()
 
         data_frame = frame_factory.build_data_frame(b'hi there')

--- a/test/test_state_machines.py
+++ b/test/test_state_machines.py
@@ -170,5 +170,11 @@ class TestStreamStateMachine(object):
         c = h2.stream.H2StreamStateMachine(stream_id=1)
         c.state = h2.stream.StreamState.CLOSED
 
-        with pytest.raises(h2.exceptions.StreamClosedError):
+        expected_error = (
+            h2.exceptions.ProtocolError
+            if input_ == h2.stream.StreamInputs.SEND_PUSH_PROMISE
+            else h2.exceptions.StreamClosedError
+        )
+
+        with pytest.raises(expected_error):
             c.process_input(input_)

--- a/test/test_stream_reset.py
+++ b/test/test_stream_reset.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+"""
+test_stream_reset
+~~~~~~~~~~~~~~~~~
+
+More complex tests that exercise stream resetting functionality to validate
+that connection state is appropriately maintained.
+
+Specifically, these tests validate that streams that have been reset accurately
+keep track of connection-level state.
+"""
+import pytest
+
+import h2.connection
+import h2.errors
+import h2.events
+
+
+class TestStreamReset(object):
+    """
+    Tests for resetting streams.
+    """
+    example_request_headers = [
+        (':authority', 'example.com'),
+        (':path', '/'),
+        (':scheme', 'https'),
+        (':method', 'GET'),
+    ]
+    example_response_headers = [
+        (':status', '200'),
+        ('server', 'fake-serv/0.1.0'),
+        ('content-length', '0')
+    ]
+
+    def test_reset_stream_keeps_header_state_correct(self, frame_factory):
+        """
+        A stream that has been reset still affects the header decoder.
+        """
+        c = h2.connection.H2Connection(client_side=True)
+        c.initiate_connection()
+        c.send_headers(stream_id=1, headers=self.example_request_headers)
+        c.reset_stream(stream_id=1)
+        c.send_headers(stream_id=3, headers=self.example_request_headers)
+        c.clear_outbound_data_buffer()
+
+        f = frame_factory.build_headers_frame(
+            headers=self.example_response_headers, stream_id=1
+        )
+        events = c.receive_data(f.serialize())
+        assert not events
+        assert not c.data_to_send()
+
+        # This works because the header state should be intact from the headers
+        # frame that was send on stream 1, so they should decode cleanly.
+        f = frame_factory.build_headers_frame(
+            headers=self.example_response_headers, stream_id=3
+        )
+        event = c.receive_data(f.serialize())[0]
+
+        assert isinstance(event, h2.events.ResponseReceived)
+        assert event.stream_id == 3
+        assert event.headers == self.example_response_headers
+
+    @pytest.mark.parametrize('close_id,other_id', [(1, 3), (3, 1)])
+    def test_reset_stream_keeps_flow_control_correct(self,
+                                                     close_id,
+                                                     other_id,
+                                                     frame_factory):
+        """
+        A stream that has been reset still affects the connection flow control
+        window.
+        """
+        c = h2.connection.H2Connection(client_side=True)
+        c.initiate_connection()
+        c.send_headers(stream_id=1, headers=self.example_request_headers)
+        c.send_headers(stream_id=3, headers=self.example_request_headers)
+
+        # Record the initial window size.
+        initial_window = c.remote_flow_control_window(stream_id=other_id)
+
+        f = frame_factory.build_headers_frame(
+            headers=self.example_response_headers, stream_id=close_id
+        )
+        c.receive_data(f.serialize())
+        c.reset_stream(stream_id=close_id)
+        c.clear_outbound_data_buffer()
+
+        f = frame_factory.build_data_frame(
+            data=b'some data!',
+            stream_id=close_id
+        )
+        events = c.receive_data(f.serialize())
+        assert not events
+        assert not c.data_to_send()
+
+        new_window = c.remote_flow_control_window(stream_id=other_id)
+        assert initial_window - len(b'some data!') == new_window
+
+    def test_reset_stream_automatically_resets_pushed_streams(self,
+                                                              frame_factory):
+        """
+        Resetting a stream causes RST_STREAM frames to be automatically emitted
+        to close any streams pushed after the reset.
+        """
+        c = h2.connection.H2Connection(client_side=True)
+        c.initiate_connection()
+        c.send_headers(stream_id=1, headers=self.example_request_headers)
+        c.reset_stream(stream_id=1)
+        c.clear_outbound_data_buffer()
+
+        f = frame_factory.build_push_promise_frame(
+            stream_id=1,
+            promised_stream_id=2,
+            headers=self.example_request_headers,
+        )
+        events = c.receive_data(f.serialize())
+        assert not events
+
+        f = frame_factory.build_rst_stream_frame(
+            stream_id=2,
+            error_code=h2.errors.REFUSED_STREAM,
+        )
+        assert c.data_to_send() == f.serialize()


### PR DESCRIPTION
Resolves #157.

This turned out to be a *really* gnarly patch. There are a couple of commits in here that contain long explanations of why I made certain decisions, and I'm honestly not 100% on those decisions being sensible: however, I think we have a defensible position here. I'd like to write a few more tests that validate that we really do ignore frames that we should ignore, but for the most part I believe these tests correctly validate our behaviour. Certainly the tests prove that HEADERS, DATA, and PUSH_PROMISE are correctly handled for streams that are reset by our users.

This also ignores the role of PRIORITY frames, which I propose to handle separately in #168.