### PR TITLE
Default SETTINGS_MAX_CONCURRENT_STREAMS to 100.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,6 +17,9 @@ Bugfixes
 
 - Correctly reject all of the connection-specific headers mentioned in RFC 7540
   § 8.1.2.2, not just the ``Connection:`` header.
+- Defaulted the value of ``SETTINGS_MAX_CONCURRENT_STREAMS`` to 100, unless
+  explicitly overridden. This is a safe defensive initial value for this
+  setting.
 - Reject attempts to push streams on streams that were themselves pushed:
   streams can only be pushed on streams that were initiated by the client.
 - Correctly allow CONTINUATION frames to extend the header block started by a

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,7 @@ API Changes (Backward-Compatible)
 - Added an ``additional_data`` field to the ``ConnectionTerminated`` event that
   carries any additional data sent on the GOAWAY frame. May be ``None`` if no
   such data was sent.
+- Added the ``initial_values`` optional argument to the ``Settings`` object.
 
 Bugfixes
 ~~~~~~~~

--- a/h2/settings.py
+++ b/h2/settings.py
@@ -66,7 +66,7 @@ class Settings(collections.MutableMapping):
     Finally, this object understands what the default values of the HTTP/2
     settings are, and sets those defaults appropriately.
     """
-    def __init__(self, client=True):
+    def __init__(self, client=True, initial_values=None):
         # Backing object for the settings. This is a dictionary of
         # (setting: [list of values]), where the first value in the list is the
         # current value of the setting. Strictly this doesn't use lists but
@@ -79,6 +79,15 @@ class Settings(collections.MutableMapping):
             INITIAL_WINDOW_SIZE: collections.deque([65535]),
             MAX_FRAME_SIZE: collections.deque([16384]),
         }
+        if initial_values is not None:
+            for key, value in initial_values.items():
+                invalid = _validate_setting(key, value)
+                if invalid:
+                    raise InvalidSettingsValueError(
+                        "Setting %d has invalid value %d" % (key, value),
+                        error_code=invalid
+                    )
+                self._settings[key] = collections.deque([value])
 
     def acknowledge(self):
         """

--- a/h2/settings.py
+++ b/h2/settings.py
@@ -65,6 +65,16 @@ class Settings(collections.MutableMapping):
 
     Finally, this object understands what the default values of the HTTP/2
     settings are, and sets those defaults appropriately.
+
+    .. versionchanged:: 2.2.0
+       Added the ``initial_values`` parameter.
+
+    :param client: (optional) Whether these settings should be defaulted for a
+        client implementation or a server implementation. Defaults to ``True``.
+    :type client: ``bool``
+    :param initial_values: (optional) Any initial values the user would like
+        set, rather than RFC 7540's defaults.
+    :type initial_vales: ``MutableMapping``
     """
     def __init__(self, client=True, initial_values=None):
         # Backing object for the settings. This is a dictionary of

--- a/test/test_interacting_stacks.py
+++ b/test/test_interacting_stacks.py
@@ -22,6 +22,7 @@ import coroutine_tests
 
 import h2.connection
 import h2.events
+import h2.settings
 
 
 class TestCommunication(coroutine_tests.CoroutineTestCase):
@@ -57,6 +58,10 @@ class TestCommunication(coroutine_tests.CoroutineTestCase):
             assert len(events) == 2
             assert isinstance(events[0], h2.events.SettingsAcknowledged)
             assert isinstance(events[1], h2.events.RemoteSettingsChanged)
+            changed = events[1].changed_settings
+            assert (
+                changed[h2.settings.MAX_CONCURRENT_STREAMS].new_value == 100
+            )
 
             # Send a request.
             events = c.send_headers(1, request_headers, end_stream=True)
@@ -81,6 +86,10 @@ class TestCommunication(coroutine_tests.CoroutineTestCase):
             events = c.receive_data(data)
             assert len(events) == 1
             assert isinstance(events[0], h2.events.RemoteSettingsChanged)
+            changed = events[0].changed_settings
+            assert (
+                changed[h2.settings.MAX_CONCURRENT_STREAMS].new_value == 100
+            )
 
             # Send our preamble back.
             c.initiate_connection()

--- a/test/test_settings.py
+++ b/test/test_settings.py
@@ -41,6 +41,46 @@ class TestSettings(object):
         assert s[h2.settings.INITIAL_WINDOW_SIZE] == 65535
         assert s[h2.settings.MAX_FRAME_SIZE] == 16384
 
+    @pytest.mark.parametrize('client', [True, False])
+    def test_can_set_initial_values(self, client):
+        """
+        The Settings object can be provided initial values that override the
+        defaults.
+        """
+        overrides = {
+            h2.settings.HEADER_TABLE_SIZE: 8080,
+            h2.settings.MAX_FRAME_SIZE: 16388,
+            h2.settings.MAX_CONCURRENT_STREAMS: 100,
+        }
+        s = h2.settings.Settings(client=client, initial_values=overrides)
+
+        assert s[h2.settings.HEADER_TABLE_SIZE] == 8080
+        assert s[h2.settings.ENABLE_PUSH] == bool(client)
+        assert s[h2.settings.INITIAL_WINDOW_SIZE] == 65535
+        assert s[h2.settings.MAX_FRAME_SIZE] == 16388
+        assert s[h2.settings.MAX_CONCURRENT_STREAMS] == 100
+
+    @pytest.mark.parametrize(
+        'setting,value',
+        [
+            (h2.settings.ENABLE_PUSH, 2),
+            (h2.settings.ENABLE_PUSH, -1),
+            (h2.settings.INITIAL_WINDOW_SIZE, -1),
+            (h2.settings.INITIAL_WINDOW_SIZE, 2**34),
+            (h2.settings.MAX_FRAME_SIZE, 1),
+            (h2.settings.MAX_FRAME_SIZE, 2**30),
+        ]
+    )
+    def test_cannot_set_invalid_initial_values(self, setting, value):
+        """
+        The Settings object can be provided initial values that override the
+        defaults.
+        """
+        overrides = {setting: value}
+
+        with pytest.raises(h2.exceptions.InvalidSettingsValueError):
+            h2.settings.Settings(initial_values=overrides)
+
     def test_applying_value_doesnt_take_effect_immediately(self):
         """
         When a value is applied to the settings object, it doesn't immediately


### PR DESCRIPTION
Resolves #156.