### PR TITLE
Deprecate the use of dictionaries for headers.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -21,6 +21,12 @@ Bugfixes
   explicitly overridden. This is a safe defensive initial value for this
   setting.
 
+Deprecations
+~~~~~~~~~~~~
+
+- Passing dictionaries to ``send_headers`` as the header block is deprecated,
+  and will be removed in 3.0.
+
 2.1.2 (2016-02-17)
 ------------------
 

--- a/docs/source/advanced-usage.rst
+++ b/docs/source/advanced-usage.rst
@@ -81,5 +81,31 @@ unbounded form of
 you avoid subtle bugs.
 
 
+Headers
+-------
+
+HTTP/2 defines several "special header fields" which are used to encode data
+that was previously sent in either the request or status line of HTTP/1.1.
+These header fields are distinguished from ordinary header fields because their
+field name begins with a ``:`` character. The special header fields defined in
+`RFC 7540`_ are:
+
+- ``:status``
+- ``:path``
+- ``:method``
+- ``:scheme``
+- ``:authority``
+
+`RFC 7540`_ **mandates** that all of these header fields appear *first* in the
+header block, before the ordinary header fields. This can cause difficulty if
+you call the :meth:`send_headers <h2.connection.H2Connection.send_headers>`
+method with a plain ``dict`` for the ``headers`` argument, because ``dict``
+objects are unordered.
+
+For this reason, passing a ``dict`` to ``send_headers`` is *deprecated* as of
+the 2.1 series of releases. This functionality will be removed entirely in
+version 3.0 of hyper-h2.
+
+
 .. _RFC 7540: https://tools.ietf.org/html/rfc7540
 .. _an implementation: http://python-hyper/priority/

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -513,6 +513,14 @@ class H2Connection(object):
         In all situations it is a protocol error to call ``send_headers`` more
         than twice.
 
+        .. warning:: In HTTP/2, it is mandatory that all the HTTP/2 special
+            headers (that is, ones whose header keys begin with ``:``) appear
+            at the start of the header block, before any normal headers.
+            If you pass a dictionary to the ``headers`` parameter, it is
+            unlikely that they will iterate in that order, and your connection
+            may fail. For this reason, passing a ``dict`` to ``headers`` is
+            *deprecated*, and will be removed in 3.0.
+
         :param stream_id: The stream ID to send the headers on. If this stream
             does not currently exist, it will be created.
         :type stream_id: ``int``

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -5,6 +5,8 @@ h2/stream
 
 An implementation of a HTTP/2 stream.
 """
+import warnings
+
 from enum import Enum, IntEnum
 from hyperframe.frame import (
     HeadersFrame, ContinuationFrame, DataFrame, WindowUpdateFrame,
@@ -779,7 +781,13 @@ class H2Stream(object):
         Helper method to build headers or push promise frames.
         """
         # Convert headers to two-tuples.
+        # FIXME: The fallback for dictionary headers is to be removed in 3.0.
         try:
+            warnings.warn(
+                "Implicit conversion of dictionaries to two-tuples for "
+                "headers is deprecated and will be removed in 3.0.",
+                DeprecationWarning
+            )
             headers = headers.items()
         except AttributeError:
             headers = headers


### PR DESCRIPTION
Following on from the discussion on python-hyper/hpack#32, this change deprecates the conversion of headers from dictionaries into iterables of two-tuples. The issue for actually removing this deprecation is in #183.