### PR TITLE
Allow informational responses in the HALF_CLOSED_* states.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,14 @@ Release History
 dev
 ---
 
+Bugfixes
+~~~~~~~~
+
+- Fixed issue where informational responses were erroneously not allowed to be
+  sent in the ``HALF_CLOSED_REMOTE`` state.
+- Fixed issue where informational responses were erroneously not allowed to be
+  received in the ``HALF_CLOSED_LOCAL`` state.
+
 2.2.1 (2016-03-23)
 ------------------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,8 @@ Bugfixes
   sent in the ``HALF_CLOSED_REMOTE`` state.
 - Fixed issue where informational responses were erroneously not allowed to be
   received in the ``HALF_CLOSED_LOCAL`` state.
+- Fixed issue where we allowed information responses to be sent or received
+  after final responses.
 
 2.2.1 (2016-03-23)
 ------------------

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -479,6 +479,8 @@ _transitions = {
         (H2StreamStateMachine.send_reset, StreamState.CLOSED),
     (StreamState.HALF_CLOSED_REMOTE, StreamInputs.RECV_CONTINUATION):
         (H2StreamStateMachine.send_reset, StreamState.CLOSED),
+    (StreamState.HALF_CLOSED_REMOTE, StreamInputs.SEND_INFORMATIONAL_HEADERS):
+        (None, StreamState.HALF_CLOSED_REMOTE),
 
     # State: half-closed local
     (StreamState.HALF_CLOSED_LOCAL, StreamInputs.RECV_HEADERS):
@@ -498,6 +500,9 @@ _transitions = {
         (H2StreamStateMachine.stream_reset, StreamState.CLOSED),
     (StreamState.HALF_CLOSED_LOCAL, StreamInputs.RECV_PUSH_PROMISE):
         (H2StreamStateMachine.recv_push_promise,
+            StreamState.HALF_CLOSED_LOCAL),
+    (StreamState.HALF_CLOSED_LOCAL, StreamInputs.RECV_INFORMATIONAL_HEADERS):
+        (H2StreamStateMachine.recv_informational_response,
             StreamState.HALF_CLOSED_LOCAL),
 
     # State: closed

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -300,11 +300,26 @@ class H2StreamStateMachine(object):
         assert previous_state == StreamState.CLOSED
         raise ProtocolError("Attempted to push on closed stream.")
 
+    def send_informational_response(self, previous_state):
+        """
+        Called when an informational header block is sent (that is, a block
+        where the :status header has a 1XX value).
+
+        Only enforces that these are sent *before* final headers are sent.
+        """
+        if self.headers_sent:
+            raise ProtocolError("Information response after final response")
+
+        return []
+
     def recv_informational_response(self, previous_state):
         """
         Called when an informational header block is received (that is, a block
         where the :status header has a 1XX value).
         """
+        if self.headers_received:
+            raise ProtocolError("Informational response after final response")
+
         event = InformationalResponseReceived()
         event.stream_id = self.stream_id
         return [event]
@@ -449,7 +464,7 @@ _transitions = {
     (StreamState.OPEN, StreamInputs.RECV_PUSH_PROMISE):
         (H2StreamStateMachine.recv_push_promise, StreamState.OPEN),
     (StreamState.OPEN, StreamInputs.SEND_INFORMATIONAL_HEADERS):
-        (None, StreamState.OPEN),
+        (H2StreamStateMachine.send_informational_response, StreamState.OPEN),
     (StreamState.OPEN, StreamInputs.RECV_INFORMATIONAL_HEADERS):
         (H2StreamStateMachine.recv_informational_response, StreamState.OPEN),
 
@@ -480,7 +495,8 @@ _transitions = {
     (StreamState.HALF_CLOSED_REMOTE, StreamInputs.RECV_CONTINUATION):
         (H2StreamStateMachine.send_reset, StreamState.CLOSED),
     (StreamState.HALF_CLOSED_REMOTE, StreamInputs.SEND_INFORMATIONAL_HEADERS):
-        (None, StreamState.HALF_CLOSED_REMOTE),
+        (H2StreamStateMachine.send_informational_response,
+            StreamState.HALF_CLOSED_REMOTE),
 
     # State: half-closed local
     (StreamState.HALF_CLOSED_LOCAL, StreamInputs.RECV_HEADERS):

--- a/test/test_informational_responses.py
+++ b/test/test_informational_responses.py
@@ -36,14 +36,19 @@ class TestReceivingInformationalResponses(object):
         ('trailer', 'you-bet'),
     ]
 
-    def test_single_informational_response(self, frame_factory):
+    @pytest.mark.parametrize('end_stream', (True, False))
+    def test_single_informational_response(self, frame_factory, end_stream):
         """
         When receiving a informational response, the appropriate event is
         signaled.
         """
         c = h2.connection.H2Connection(client_side=True)
         c.initiate_connection()
-        c.send_headers(stream_id=1, headers=self.example_request_headers)
+        c.send_headers(
+            stream_id=1,
+            headers=self.example_request_headers,
+            end_stream=end_stream
+        )
 
         f = frame_factory.build_headers_frame(
             headers=self.example_informational_headers,
@@ -58,14 +63,19 @@ class TestReceivingInformationalResponses(object):
         assert event.headers == self.example_informational_headers
         assert event.stream_id == 1
 
-    def test_receiving_multiple_header_blocks(self, frame_factory):
+    @pytest.mark.parametrize('end_stream', (True, False))
+    def test_receiving_multiple_header_blocks(self, frame_factory, end_stream):
         """
         At least three header blocks can be received: informational, headers,
         trailers.
         """
         c = h2.connection.H2Connection(client_side=True)
         c.initiate_connection()
-        c.send_headers(stream_id=1, headers=self.example_request_headers)
+        c.send_headers(
+            stream_id=1,
+            headers=self.example_request_headers,
+            end_stream=end_stream
+        )
 
         f1 = frame_factory.build_headers_frame(
             headers=self.example_informational_headers,
@@ -98,13 +108,20 @@ class TestReceivingInformationalResponses(object):
         assert events[2].headers == self.example_trailers
         assert events[2].stream_id == 1
 
-    def test_receiving_multiple_informational_responses(self, frame_factory):
+    @pytest.mark.parametrize('end_stream', (True, False))
+    def test_receiving_multiple_informational_responses(self,
+                                                        frame_factory,
+                                                        end_stream):
         """
         More than one informational response is allowed.
         """
         c = h2.connection.H2Connection(client_side=True)
         c.initiate_connection()
-        c.send_headers(stream_id=1, headers=self.example_request_headers)
+        c.send_headers(
+            stream_id=1,
+            headers=self.example_request_headers,
+            end_stream=end_stream
+        )
 
         f1 = frame_factory.build_headers_frame(
             headers=self.example_informational_headers,
@@ -126,14 +143,21 @@ class TestReceivingInformationalResponses(object):
         assert events[1].headers == [(':status', '101')]
         assert events[1].stream_id == 1
 
-    def test_receive_provisional_response_with_end_stream(self, frame_factory):
+    @pytest.mark.parametrize('end_stream', (True, False))
+    def test_receive_provisional_response_with_end_stream(self,
+                                                          frame_factory,
+                                                          end_stream):
         """
         Receiving provisional responses with END_STREAM set causes
         ProtocolErrors.
         """
         c = h2.connection.H2Connection(client_side=True)
         c.initiate_connection()
-        c.send_headers(stream_id=1, headers=self.example_request_headers)
+        c.send_headers(
+            stream_id=1,
+            headers=self.example_request_headers,
+            end_stream=end_stream
+        )
         c.clear_outbound_data_buffer()
 
         f = frame_factory.build_headers_frame(
@@ -182,7 +206,11 @@ class TestSendingInformationalResponses(object):
     @pytest.mark.parametrize(
         'hdrs', (unicode_informational_headers, bytes_informational_headers),
     )
-    def test_single_informational_response(self, frame_factory, hdrs):
+    @pytest.mark.parametrize('end_stream', (True, False))
+    def test_single_informational_response(self,
+                                           frame_factory,
+                                           hdrs,
+                                           end_stream):
         """
         When sending a informational response, the appropriate frames are
         emitted.
@@ -190,9 +218,11 @@ class TestSendingInformationalResponses(object):
         c = h2.connection.H2Connection(client_side=False)
         c.initiate_connection()
         c.receive_data(frame_factory.preamble())
+        flags = ['END_STREAM'] if end_stream else []
         f = frame_factory.build_headers_frame(
             headers=self.example_request_headers,
-            stream_id=1
+            stream_id=1,
+            flags=flags,
         )
         c.receive_data(f.serialize())
         c.clear_outbound_data_buffer()
@@ -212,7 +242,11 @@ class TestSendingInformationalResponses(object):
     @pytest.mark.parametrize(
         'hdrs', (unicode_informational_headers, bytes_informational_headers),
     )
-    def test_sending_multiple_header_blocks(self, frame_factory, hdrs):
+    @pytest.mark.parametrize('end_stream', (True, False))
+    def test_sending_multiple_header_blocks(self,
+                                            frame_factory,
+                                            hdrs,
+                                            end_stream):
         """
         At least three header blocks can be sent: informational, headers,
         trailers.
@@ -220,9 +254,11 @@ class TestSendingInformationalResponses(object):
         c = h2.connection.H2Connection(client_side=False)
         c.initiate_connection()
         c.receive_data(frame_factory.preamble())
+        flags = ['END_STREAM'] if end_stream else []
         f = frame_factory.build_headers_frame(
             headers=self.example_request_headers,
-            stream_id=1
+            stream_id=1,
+            flags=flags,
         )
         c.receive_data(f.serialize())
         c.clear_outbound_data_buffer()
@@ -265,18 +301,22 @@ class TestSendingInformationalResponses(object):
     @pytest.mark.parametrize(
         'hdrs', (unicode_informational_headers, bytes_informational_headers),
     )
+    @pytest.mark.parametrize('end_stream', (True, False))
     def test_sending_multiple_informational_responses(self,
                                                       frame_factory,
-                                                      hdrs):
+                                                      hdrs,
+                                                      end_stream):
         """
         More than one informational response is allowed.
         """
         c = h2.connection.H2Connection(client_side=False)
         c.initiate_connection()
         c.receive_data(frame_factory.preamble())
+        flags = ['END_STREAM'] if end_stream else []
         f = frame_factory.build_headers_frame(
             headers=self.example_request_headers,
-            stream_id=1
+            stream_id=1,
+            flags=flags,
         )
         c.receive_data(f.serialize())
         c.clear_outbound_data_buffer()
@@ -306,9 +346,11 @@ class TestSendingInformationalResponses(object):
     @pytest.mark.parametrize(
         'hdrs', (unicode_informational_headers, bytes_informational_headers),
     )
+    @pytest.mark.parametrize('end_stream', (True, False))
     def test_send_provisional_response_with_end_stream(self,
                                                        frame_factory,
-                                                       hdrs):
+                                                       hdrs,
+                                                       end_stream):
         """
         Sending provisional responses with END_STREAM set causes
         ProtocolErrors.
@@ -316,9 +358,11 @@ class TestSendingInformationalResponses(object):
         c = h2.connection.H2Connection(client_side=False)
         c.initiate_connection()
         c.receive_data(frame_factory.preamble())
+        flags = ['END_STREAM'] if end_stream else []
         f = frame_factory.build_headers_frame(
             headers=self.example_request_headers,
-            stream_id=1
+            stream_id=1,
+            flags=flags,
         )
         c.receive_data(f.serialize())
 


### PR DESCRIPTION
This must have just been an oversight, but we were forbidding 1XX responses in the half closed local and half closed remote states. There's no reason for that: they're entirely allowed.

This patch isn't complete yet: we need to tighten up our processing to ensure that informational headers are never sent/received after the actual response headers.