### PR TITLE
Allow users to obtain raw headers.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,16 @@ Release History
 dev
 ---
 
+API Changes (Backward-Compatible)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Added a new flag to the ``H2Connection`` constructor: ``header_encoding``,
+  that controls what encoding is used (if any) to decode the headers from bytes
+  to unicode. This defaults to UTF-8 for backward compatibility. To disable the
+  decode and use bytes exclusively, set the field to False, None, or the empty
+  string.
+- Bumped the minimum version of HPACK allowed from 2.0 to 2.1.
+
 2.2.3 (2016-04-13)
 ------------------
 

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -749,7 +749,7 @@ class H2Stream(object):
         )
         return [], events
 
-    def receive_headers(self, headers, end_stream):
+    def receive_headers(self, headers, end_stream, header_encoding):
         """
         Receive a set of headers (or trailers).
         """
@@ -774,6 +774,12 @@ class H2Stream(object):
         if isinstance(events[0], TrailersReceived):
             if not end_stream:
                 raise ProtocolError("Trailers must have END_STREAM set")
+
+        if header_encoding:
+            headers = [
+                (n.decode(header_encoding), v.decode(header_encoding))
+                for n, v in headers
+            ]
 
         events[0].headers = headers
         return [], events
@@ -882,7 +888,7 @@ class H2Stream(object):
         Content-Length header to be present.
         """
         for n, v in headers:
-            if n == 'content-length':
+            if n == b'content-length':
                 try:
                     self._expected_content_length = int(v, 10)
                 except ValueError:

--- a/h2/utilities.py
+++ b/h2/utilities.py
@@ -9,16 +9,16 @@ import re
 
 from .exceptions import ProtocolError, FlowControlError
 
-UPPER_RE = re.compile("[A-Z]")
+UPPER_RE = re.compile(b"[A-Z]")
 
 # A set of headers that are hop-by-hop or connection-specific and thus
 # forbidden in HTTP/2. This list comes from RFC 7540 § 8.1.2.2.
 CONNECTION_HEADERS = set([
-    'connection',
-    'proxy-connection',
-    'keep-alive',
-    'transfer-encoding',
-    'upgrade',
+    b'connection',
+    b'proxy-connection',
+    b'keep-alive',
+    b'transfer-encoding',
+    b'upgrade',
 ])
 
 
@@ -117,8 +117,8 @@ def _reject_te(headers):
     its value is anything other than "trailers".
     """
     for header in headers:
-        if header[0] == 'te':
-            if header[1].lower().strip() != 'trailers':
+        if header[0] == b'te':
+            if header[1].lower().strip() != b'trailers':
                 raise ProtocolError(
                     "Invalid value for Transfer-Encoding header: %s" %
                     header[1]
@@ -151,7 +151,7 @@ def _reject_pseudo_header_fields(headers):
     seen_regular_header = False
 
     for header in headers:
-        if header[0].startswith(':'):
+        if header[0].startswith(b':'):
             if header[0] in seen_pseudo_header_fields:
                 raise ProtocolError(
                     "Received duplicate pseudo-header field %s" % header[0]

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     ],
     install_requires=[
         'hyperframe>=3.1, <5, !=4.0.0',
-        'hpack>=2.0, <3',
+        'hpack>=2.1, <3',
     ],
     extras_require={
         ':python_version == "2.7" or python_version == "3.3"': ['enum34>=1.0.4, <2'],

--- a/test/test_invalid_headers.py
+++ b/test/test_invalid_headers.py
@@ -15,9 +15,9 @@ import h2.exceptions
 import h2.utilities
 
 from hypothesis import given
-from hypothesis.strategies import text, lists, tuples
+from hypothesis.strategies import binary, lists, tuples
 
-HEADERS_STRATEGY = lists(tuples(text(), text()))
+HEADERS_STRATEGY = lists(tuples(binary(), binary()))
 
 
 class TestInvalidFrameSequences(object):


### PR DESCRIPTION
This change adds a new flag that allows users to request 'raw' headers: that is, headers that have not been decoded to unicode and are still in bytes form. This was originally requested by the Twisted developers who use a bytes internal headers representation, though it may well be useful for others.

This change involves quite a substantial internal change: we now have headers move through the body of hyper-h2 in bytes form, and only get encoded at the edge.

This change introduces one unfortunate problem: we need to bump the minimum version of HPACK we can use. I believe this is safe to do in a semver-minor release, as we're only bumping the minor version, so the upgrade should be safe.

The default output for headers *remains* unicode. That may change in 3.0.0 (per #154), but for now we're leaving it as-is.