### PR TITLE
Disallow custom pseudo-headers

### DIFF
--- a/h2/utilities.py
+++ b/h2/utilities.py
@@ -22,6 +22,15 @@ CONNECTION_HEADERS = set([
 ])
 
 
+_ALLOWED_PSEUDO_HEADER_FIELDS = set([
+    b':method',
+    b':scheme',
+    b':authority',
+    b':path',
+    b':status',
+])
+
+
 def is_informational_response(headers):
     """
     Searches a header block for a :status header to confirm that a given
@@ -164,6 +173,12 @@ def _reject_pseudo_header_fields(headers):
                     "Received pseudo-header field out of sequence: %s" %
                     header[0]
                 )
+
+            if header[0] not in _ALLOWED_PSEUDO_HEADER_FIELDS:
+                raise ProtocolError(
+                    "Received custom pseudo-header field %s" % header[0]
+                )
+
         else:
             seen_regular_header = True
 

--- a/test/test_invalid_headers.py
+++ b/test/test_invalid_headers.py
@@ -102,3 +102,8 @@ class TestFilter(object):
             assert headers == h2.utilities.validate_headers(headers)
         except h2.exceptions.ProtocolError:
             assert True
+
+    def test_invalid_pseudo_headers(self):
+        headers = [(b':custom', b'value')]
+        with pytest.raises(h2.exceptions.ProtocolError):
+            h2.utilities.validate_headers(headers)


### PR DESCRIPTION
I had a look at `hypothesis` and realized that the test that was already present in `TestFilter` is testing the "good case", so I only created a test for an invalid pseudo-header, correct me if I'm wrong, but I found no way to do something like what I did in the test in a `hypothesis` way.