### PR TITLE
Automatically prevent some headers from being indexed.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -24,6 +24,8 @@ Bugfixes
 ~~~~~~~~
 
 - Correctly forbid pseudo-headers that were not defined in RFC 7540.
+- Automatically ensure that all ``Authorization`` headers and short ``Cookie``
+  headers are prevented from being added to encoding contexts.
 
 2.2.3 (2016-04-13)
 ------------------

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -24,7 +24,8 @@ from .exceptions import (
     ProtocolError, StreamClosedError, InvalidBodyLengthError
 )
 from .utilities import (
-    guard_increment_window, is_informational_response, authority_from_headers
+    guard_increment_window, is_informational_response, authority_from_headers,
+    secure_headers
 )
 
 
@@ -988,8 +989,10 @@ class H2Stream(object):
         """
         Helper method to build headers or push promise frames.
         """
-        # We need to lowercase the header names.
+        # We need to lowercase the header names, and to ensure that secure
+        # header fields are kept out of compression contexts.
         headers = _lowercase_header_names(headers)
+        headers = secure_headers(headers)
         encoded_headers = encoder.encode(headers)
 
         # Slice into blocks of max_outbound_frame_size. Be careful with this:


### PR DESCRIPTION
Resolves #194.

This change implements the final part of #194: automatically preventing certain header fields from being indexed. This specifically implements the suggestion from @tatsuhiro-t: namely, all Authorization headers and short Cookie headers are forced to be never indexed.