### PR TITLE
Support for plaintext upgrade.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -19,6 +19,8 @@ API Changes (Backward-Compatible)
 - Changed all events that carry headers to emit ``hpack.HeaderTuple`` and
   ``hpack.NeverIndexedHeaderTuple`` instead of plain tuples. This allows users
   to maintain header indexing state.
+- Added support for plaintext upgrade with the ``initiate_upgrade_connection``
+  method.
 
 Bugfixes
 ~~~~~~~~

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -266,4 +266,5 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3.5/', None),
     'hpack': ('https://python-hyper.org/hpack/en/stable/', None),
+    'pyopenssl': ('https://pyopenssl.readthedocs.org/en/latest/', None),
 }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,6 +30,7 @@ Contents
 
    installation
    basic-usage
+   negotiating-http2
    examples
    advanced-usage
    api

--- a/docs/source/negotiating-http2.rst
+++ b/docs/source/negotiating-http2.rst
@@ -1,0 +1,56 @@
+Negotiating HTTP/2
+==================
+
+`RFC 7540`_ specifies three methods of negotiating HTTP/2 connections. This document outlines how to use Hyper-h2 with each one.
+
+.. _starting-alpn:
+
+HTTPS URLs (ALPN and NPN)
+-------------------------
+
+Starting HTTP/2 for HTTPS URLs is outlined in `RFC 7540 Section 3.3`_. In this case, the client and server use a TLS extension to negotiate HTTP/2: typically either or both of `NPN`_ or `ALPN`_. How to use NPN and ALPN is currently not covered in this document: please consult the documentation for either the :mod:`ssl module <python:ssl>` in the standard library, or the :mod:`PyOpenSSL <pyopenssl:OpenSSL.SSL>` third-party modules, for more on this topic.
+
+This method is the simplest to use once the TLS connection is established. To use it with Hyper-h2, after you've established the connection and confirmed that HTTP/2 has been negotiated with `ALPN`_, create a :class:`H2Connection <h2.connection.H2Connection>` object and call :meth:`H2Connection.initiate_connection <h2.connection.H2Connection.initiate_connection>`. This will ensure that the appropriate preamble data is placed in the data buffer. You should then immediately send the data returned by :meth:`H2Connection.data_to_send <h2.connection.H2Connection.data_to_send>` on your TLS connection.
+
+At this point, you're free to use all the HTTP/2 functionality provided by Hyper-h2.
+
+.. _starting-upgrade:
+
+HTTP URLs (Upgrade)
+-------------------
+
+Starting HTTP/2 for HTTP URLs is outlined in `RFC 7540 Section 3.2`_. In this case, the client and server use the HTTP Upgrade mechanism originally described in `RFC 7230 Section 6.7`_. The client sends its initial HTTP/1.1 request with two extra headers. The first is ``Upgrade: h2c``, which requests upgrade to cleartext HTTP/2. The second is a ``HTTP2-Settings`` header, which contains a specially formatted string that encodes a HTTP/2 Settings frame.
+
+To do this with Hyper-h2 you have two slightly different flows: one for clients, one for servers.
+
+Clients
+~~~~~~~
+
+For a client, when sending the first request you should manually add your ``Upgrade`` header. You should then create a :class:`H2Connection <h2.connection.H2Connection>` object and call :meth:`H2Connection.initiate_upgrade_connection <h2.connection.H2Connection.initiate_upgrade_connection>` with no arguments. This method will return a bytestring to use as the value of your ``HTTP2-Settings`` header.
+
+If the server returns a ``101`` status code, it has accepted the upgrade, and you should immediately send the data returned by :meth:`H2Connection.data_to_send <h2.connection.H2Connection.data_to_send>`. Now you should consume the entire ``101`` header block. All data after the ``101`` header block is HTTP/2 data that should be fed directly to :meth:`H2Connection.receive_data <h2.connection.H2Connection.receive_data>` and handled as normal with Hyper-h2.
+
+If the server does not return a ``101`` status code then it is not upgrading. Continue with HTTP/1.1 as normal: you may throw away your :class:`H2Connection <h2.connection.H2Connection>` object, as it is of no further use.
+
+The server will respond to your original request in HTTP/2. Please pay attention to the events received from Hyper-h2, as they will define the server's response.
+
+Servers
+~~~~~~~
+
+If the first request you receive on a connection from the client contains an ``Upgrade`` header with the ``h2c`` token in it, and you're willing to upgrade, you should create a :class:`H2Connection <h2.connection.H2Connection>` object and call :meth:`H2Connection.initiate_upgrade_connection <h2.connection.H2Connection.initiate_upgrade_connection>` with the value of the ``HTTP2-Settings`` header (as a bytestring) as the only argument.
+
+Then, you should send back a ``101`` response that contains ``h2c`` in the ``Upgrade`` header. That response will inform the client that you're switching to HTTP/2. Then, you should immediately send the data that is returned to you by :meth:`H2Connection.data_to_send <h2.connection.H2Connection.data_to_send>` on the connection: this is a necessary part of the HTTP/2 upgrade process.
+
+At this point, you may now respond to the original HTTP/1.1 request in HTTP/2 by calling the appropriate methods on the :class:`H2Connection <h2.connection.H2Connection>` object. No further HTTP/1.1 may be sent on this connection: from this point onward, all data sent by you and the client will be HTTP/2 data.
+
+Prior Knowledge
+---------------
+
+It's possible that you as a client know that a particular server supports HTTP/2, and that you do not need to perform any of the negotiations decribed above. In that case, you may follow the steps in :ref:`starting-alpn`, ignoring all references to ALPN and NPN: there's no need to perform the upgrade dance described in :ref:`starting-upgrade`.
+
+.. _RFC 7540: https://tools.ietf.org/html/rfc7540
+.. _RFC 7540 Section 3.2: https://tools.ietf.org/html/rfc7540#section-3.2
+.. _RFC 7540 Section 3.3: https://tools.ietf.org/html/rfc7540#section-3.3
+.. _NPN: https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation
+.. _ALPN: https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation
+.. _RFC 7230 Section 6.7: https://tools.ietf.org/html/rfc7230#section-6.7

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -483,6 +483,8 @@ class H2Connection(object):
         Finally, this method also prepares the appropriate preamble to be sent
         after the upgrade.
 
+        .. versionadded:: 2.3.0
+
         :param settings_header: (optional, server-only): The value of the
              ``HTTP2-Settings`` header field received from the client.
         :type settings_header: ``bytes``

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -395,7 +395,6 @@ class H2StreamStateMachine(object):
         return
 
 
-
 # STATE MACHINE
 #
 # The stream state machine is defined here to avoid the need to allocate it

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -57,6 +57,8 @@ class StreamInputs(Enum):
     RECV_INFORMATIONAL_HEADERS = 14  # Added in 2.2.0
     SEND_ALTERNATIVE_SERVICE = 15  # Added in 2.3.0
     RECV_ALTERNATIVE_SERVICE = 16  # Added in 2.3.0
+    UPGRADE_CLIENT = 17  # Added 2.3.0
+    UPGRADE_SERVER = 18  # Added 2.3.0
 
 
 # This array is initialized once, and is indexed by the stream states above.
@@ -393,6 +395,7 @@ class H2StreamStateMachine(object):
         return
 
 
+
 # STATE MACHINE
 #
 # The stream state machine is defined here to avoid the need to allocate it
@@ -478,6 +481,11 @@ _transitions = {
             StreamState.RESERVED_REMOTE),
     (StreamState.IDLE, StreamInputs.RECV_ALTERNATIVE_SERVICE):
         (None, StreamState.IDLE),
+    (StreamState.IDLE, StreamInputs.UPGRADE_CLIENT):
+        (H2StreamStateMachine.request_sent, StreamState.HALF_CLOSED_LOCAL),
+    (StreamState.IDLE, StreamInputs.UPGRADE_SERVER):
+        (H2StreamStateMachine.request_received,
+            StreamState.HALF_CLOSED_REMOTE),
 
     # State: reserved local
     (StreamState.RESERVED_LOCAL, StreamInputs.SEND_HEADERS):
@@ -694,6 +702,22 @@ class H2Stream(object):
         Whether the stream is closed.
         """
         return self.state_machine.state == StreamState.CLOSED
+
+    def upgrade(self, client_side):
+        """
+        Called by the connection to indicate that this stream is the initial
+        request/response of an upgraded connection. Places the stream into an
+        appropriate state.
+        """
+        assert self.stream_id == 1
+        input_ = (
+            StreamInputs.UPGRADE_CLIENT if client_side
+            else StreamInputs.UPGRADE_SERVER
+        )
+
+        # This may return events, we deliberately don't want them.
+        self.state_machine.process_input(input_)
+        return
 
     def send_headers(self, headers, encoder, end_stream=False):
         """

--- a/test/test_h2_upgrade.py
+++ b/test/test_h2_upgrade.py
@@ -9,13 +9,29 @@ HTTP/1.1 connections to HTTP/2.
 """
 import base64
 
+import pytest
+
 import h2.connection
+import h2.errors
+import h2.events
+import h2.exceptions
 
 
 class TestClientUpgrade(object):
     """
     Tests of the client-side of the HTTP/2 upgrade dance.
     """
+    example_request_headers = [
+        (u':authority', u'example.com'),
+        (u':path', u'/'),
+        (u':scheme', u'https'),
+        (u':method', u'GET'),
+    ]
+    example_response_headers = [
+        (u':status', u'200'),
+        (u'server', u'fake-serv/0.1.0')
+    ]
+
     def test_returns_http2_settings(self, frame_factory):
         """
         Calling initiate_upgrade_connection returns a base64url encoded
@@ -34,12 +50,112 @@ class TestClientUpgrade(object):
         )
         assert decoded_frame == expected_frame.serialize()
 
+    def test_emits_preamble(self, frame_factory):
+        """
+        Calling initiate_upgrade_connection emits the connection preamble.
+        """
+        conn = h2.connection.H2Connection()
+        conn.initiate_upgrade_connection()
+
+        data = conn.data_to_send()
+        assert data.startswith(frame_factory.preamble())
+
+        data = data[len(frame_factory.preamble()):]
+        expected_frame = frame_factory.build_settings_frame(
+            settings=conn.local_settings
+        )
+        assert data == expected_frame.serialize()
+
+    def test_can_receive_response(self, frame_factory):
+        """
+        After upgrading, we can safely receive a response.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_upgrade_connection()
+        c.clear_outbound_data_buffer()
+
+        f1 = frame_factory.build_headers_frame(
+            stream_id=1,
+            headers=self.example_response_headers,
+        )
+        f2 = frame_factory.build_data_frame(
+            stream_id=1,
+            data=b'some data',
+            flags=['END_STREAM']
+        )
+        events = c.receive_data(f1.serialize() + f2.serialize())
+        assert len(events) == 3
+
+        assert isinstance(events[0], h2.events.ResponseReceived)
+        assert isinstance(events[1], h2.events.DataReceived)
+        assert isinstance(events[2], h2.events.StreamEnded)
+
+        assert events[0].headers == self.example_response_headers
+        assert events[1].data == b'some data'
+        assert all(e.stream_id == 1 for e in events)
+
+        assert not c.data_to_send()
+
+    def test_can_receive_pushed_stream(self, frame_factory):
+        """
+        After upgrading, we can safely receive a pushed stream.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_upgrade_connection()
+        c.clear_outbound_data_buffer()
+
+        f = frame_factory.build_push_promise_frame(
+            stream_id=1,
+            promised_stream_id=2,
+            headers=self.example_request_headers,
+        )
+        events = c.receive_data(f.serialize())
+        assert len(events) == 1
+
+        assert isinstance(events[0], h2.events.PushedStreamReceived)
+        assert events[0].headers == self.example_request_headers
+        assert events[0].parent_stream_id == 1
+        assert events[0].pushed_stream_id == 2
+
+    def test_cannot_send_headers_stream_1(self, frame_factory):
+        """
+        After upgrading, we cannot send headers on stream 1.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_upgrade_connection()
+        c.clear_outbound_data_buffer()
+
+        with pytest.raises(h2.exceptions.ProtocolError):
+            c.send_headers(stream_id=1, headers=self.example_request_headers)
+
+    def test_cannot_send_data_stream_1(self, frame_factory):
+        """
+        After upgrading, we cannot send data on stream 1.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_upgrade_connection()
+        c.clear_outbound_data_buffer()
+
+        with pytest.raises(h2.exceptions.ProtocolError):
+            c.send_data(stream_id=1, data=b'some data')
+
 
 
 class TestServerUpgrade(object):
     """
     Tests of the server-side of the HTTP/2 upgrade dance.
     """
+    example_request_headers = [
+        (u':authority', u'example.com'),
+        (u':path', u'/'),
+        (u':scheme', u'https'),
+        (u':method', u'GET'),
+    ]
+    example_response_headers = [
+        (u':status', u'200'),
+        (u'server', u'fake-serv/0.1.0')
+    ]
+
     def test_returns_nothing(self, frame_factory):
         """
         Calling initiate_upgrade_connection returns nothing.
@@ -48,3 +164,103 @@ class TestServerUpgrade(object):
         curl_header = "AAMAAABkAAQAAP__"
         data = conn.initiate_upgrade_connection(curl_header)
         assert data is None
+
+    def test_emits_preamble(self, frame_factory):
+        """
+        Calling initiate_upgrade_connection emits the connection preamble.
+        """
+        conn = h2.connection.H2Connection(client_side=False)
+        conn.initiate_upgrade_connection()
+
+        data = conn.data_to_send()
+        expected_frame = frame_factory.build_settings_frame(
+            settings=conn.local_settings
+        )
+        assert data == expected_frame.serialize()
+
+    def test_can_send_response(self, frame_factory):
+        """
+        After upgrading, we can safely send a response.
+        """
+        c = h2.connection.H2Connection(client_side=False)
+        c.initiate_upgrade_connection()
+        c.clear_outbound_data_buffer()
+
+        c.send_headers(stream_id=1, headers=self.example_response_headers)
+        c.send_data(stream_id=1, data=b'some data', end_stream=True)
+
+        f1 = frame_factory.build_headers_frame(
+            stream_id=1,
+            headers=self.example_response_headers,
+        )
+        f2 = frame_factory.build_data_frame(
+            stream_id=1,
+            data=b'some data',
+            flags=['END_STREAM']
+        )
+
+        expected_data = f1.serialize() + f2.serialize()
+        assert c.data_to_send() == expected_data
+
+    def test_can_push_stream(self, frame_factory):
+        """
+        After upgrading, we can safely push a stream.
+        """
+        c = h2.connection.H2Connection(client_side=False)
+        c.initiate_upgrade_connection()
+        c.clear_outbound_data_buffer()
+
+        c.push_stream(
+            stream_id=1,
+            promised_stream_id=2,
+            request_headers=self.example_request_headers
+        )
+
+        f = frame_factory.build_push_promise_frame(
+            stream_id=1,
+            promised_stream_id=2,
+            headers=self.example_request_headers,
+        )
+        assert c.data_to_send() == f.serialize()
+
+    def test_cannot_receive_headers_stream_1(self, frame_factory):
+        """
+        After upgrading, we cannot receive headers on stream 1.
+        """
+        c = h2.connection.H2Connection(client_side=False)
+        c.initiate_upgrade_connection()
+        c.receive_data(frame_factory.preamble())
+        c.clear_outbound_data_buffer()
+
+        f = frame_factory.build_headers_frame(
+            stream_id=1,
+            headers=self.example_request_headers,
+        )
+        c.receive_data(f.serialize())
+
+        expected_frame = frame_factory.build_rst_stream_frame(
+            stream_id=1,
+            error_code=h2.errors.STREAM_CLOSED,
+        )
+        assert c.data_to_send() == expected_frame.serialize()
+
+    def test_cannot_receive_data_stream_1(self, frame_factory):
+        """
+        After upgrading, we cannot receive data on stream 1.
+        """
+        c = h2.connection.H2Connection(client_side=False)
+        c.initiate_upgrade_connection()
+        c.receive_data(frame_factory.preamble())
+        c.clear_outbound_data_buffer()
+
+        f = frame_factory.build_data_frame(
+            stream_id=1,
+            data=b'some data',
+        )
+        c.receive_data(f.serialize())
+
+        expected_frame = frame_factory.build_rst_stream_frame(
+            stream_id=1,
+            error_code=h2.errors.STREAM_CLOSED,
+        )
+        assert c.data_to_send() == expected_frame.serialize()

--- a/test/test_h2_upgrade.py
+++ b/test/test_h2_upgrade.py
@@ -140,7 +140,6 @@ class TestClientUpgrade(object):
             c.send_data(stream_id=1, data=b'some data')
 
 
-
 class TestServerUpgrade(object):
     """
     Tests of the server-side of the HTTP/2 upgrade dance.

--- a/test/test_h2_upgrade.py
+++ b/test/test_h2_upgrade.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""
+test_h2_upgrade.py
+~~~~~~~~~~~~~~~~~~
+
+This module contains tests that exercise the HTTP Upgrade functionality of
+hyper-h2, ensuring that clients and servers can upgrade their plaintext
+HTTP/1.1 connections to HTTP/2.
+"""
+import base64
+
+import h2.connection
+
+
+class TestClientUpgrade(object):
+    """
+    Tests of the client-side of the HTTP/2 upgrade dance.
+    """
+    def test_returns_http2_settings(self, frame_factory):
+        """
+        Calling initiate_upgrade_connection returns a base64url encoded
+        Settings frame with the settings used by the connection.
+        """
+        conn = h2.connection.H2Connection()
+        data = conn.initiate_upgrade_connection()
+
+        # The base64 encoding must not be padded.
+        assert not data.endswith(b'=')
+
+        # However, SETTINGS frames should never need to be padded.
+        decoded_frame = base64.urlsafe_b64decode(data)
+        expected_frame = frame_factory.build_settings_frame(
+            settings=conn.local_settings
+        )
+        assert decoded_frame == expected_frame.serialize()
+
+
+
+class TestServerUpgrade(object):
+    """
+    Tests of the server-side of the HTTP/2 upgrade dance.
+    """
+    def test_returns_nothing(self, frame_factory):
+        """
+        Calling initiate_upgrade_connection returns nothing.
+        """
+        conn = h2.connection.H2Connection(client_side=False)
+        curl_header = "AAMAAABkAAQAAP__"
+        data = conn.initiate_upgrade_connection(curl_header)
+        assert data is None


### PR DESCRIPTION
Resolves #208.

Adds a new function to be called when using hyper-h2 with plaintext HTTP/2 upgrade.