### PR TITLE
Use set literals where applicable

### DIFF
--- a/h2/connection.py
+++ b/h2/connection.py
@@ -1419,7 +1419,7 @@ class H2Connection(object):
             events.append(evt)
         else:
             f = PingFrame(0)
-            f.flags = set(['ACK'])
+            f.flags = {'ACK'}
             f.opaque_data = frame.opaque_data
             flags.append(f)
 

--- a/h2/utilities.py
+++ b/h2/utilities.py
@@ -15,22 +15,22 @@ UPPER_RE = re.compile(b"[A-Z]")
 
 # A set of headers that are hop-by-hop or connection-specific and thus
 # forbidden in HTTP/2. This list comes from RFC 7540 § 8.1.2.2.
-CONNECTION_HEADERS = set([
+CONNECTION_HEADERS = {
     b'connection',
     b'proxy-connection',
     b'keep-alive',
     b'transfer-encoding',
     b'upgrade',
-])
+}
 
 
-_ALLOWED_PSEUDO_HEADER_FIELDS = set([
+_ALLOWED_PSEUDO_HEADER_FIELDS = {
     b':method',
     b':scheme',
     b':authority',
     b':path',
     b':status',
-])
+}
 
 
 _SECURE_HEADERS = frozenset([

--- a/test/test_basic_logic.py
+++ b/test/test_basic_logic.py
@@ -374,7 +374,7 @@ class TestBasicClient(object):
             map(lambda f: len(f.data) <= c.max_outbound_frame_size, frames)
         )
 
-        assert frames[0].flags == set(['END_STREAM'])
+        assert frames[0].flags == {'END_STREAM'}
 
         buffer.add_data(data[-1:])
         headers = list(buffer)[0]

--- a/test/test_complex_logic.py
+++ b/test/test_complex_logic.py
@@ -209,7 +209,7 @@ class TestContinuationFrames(object):
         frames = [
             frame_factory.build_continuation_frame(c) for c in chunks
         ]
-        f.flags = set(['END_STREAM'])
+        f.flags = {'END_STREAM'}
         frames[-1].flags.add('END_HEADERS')
         frames.insert(0, f)
         return frames
@@ -360,7 +360,7 @@ class TestContinuationFramesPushPromise(object):
         frames = [
             frame_factory.build_continuation_frame(c) for c in chunks
         ]
-        f.flags = set(['END_STREAM'])
+        f.flags = {'END_STREAM'}
         frames[-1].flags.add('END_HEADERS')
         frames.insert(0, f)
         return frames

--- a/test/test_invalid_frame_sequences.py
+++ b/test/test_invalid_frame_sequences.py
@@ -195,7 +195,7 @@ class TestInvalidFrameSequences(object):
         f = frame_factory.build_headers_frame(
             self.example_request_headers,
         )
-        f.flags = set(['END_STREAM'])
+        f.flags = {'END_STREAM'}
         c.receive_data(f.serialize())
         c.clear_outbound_data_buffer()
 


### PR DESCRIPTION
2.7 is the minimum Python version listed in setup.py
so set([...]) syntax can be replaced with {...}
syntax safely.