### PR TITLE
Emit priority data

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,10 @@ API Changes (Backward-Compatible)
   user to send additional debug data on the GOAWAY frame.
 - Adds ``last_stream_id`` to ``H2Connection.close_connection``, allowing the
   user to manually control what the reported last stream ID is.
+- Add new method: ``prioritize``.
+- Add support for emitting stream priority information when sending headers
+  frames using three new keyword arguments: ``priority_weight``,
+  ``priority_depends_on``, and ``priority_exclusive``.
 
 Bugfixes
 ~~~~~~~~

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -85,6 +85,10 @@ Exceptions
    :show-inheritance:
    :members:
 
+.. autoclass:: h2.exceptions.RFC1122Error
+   :show-inheritance:
+   :members:
+
 
 Protocol Errors
 ~~~~~~~~~~~~~~~

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -982,6 +982,96 @@ class H2Connection(object):
 
         self._prepare_for_sending(frames)
 
+    def prioritize(self, stream_id, weight=16, depends_on=0, exclusive=False):
+        """
+        Notify a server about the priority of a stream.
+
+        Stream priorities are a form of guidance to a remote server: they
+        inform the server about how important a given response is, so that the
+        server may allocate its resources (e.g. bandwidth, CPU time, etc.)
+        accordingly. This exists to allow clients to ensure that the most
+        important data arrives earlier, while less important data does not
+        starve out the more important data.
+
+        Stream priorities are explained in depth in `RFC 7540 Section 5.3
+        <https://tools.ietf.org/html/rfc7540#section-5.3>`_.
+
+        This method updates the priority information of a single stream. It may
+        be called well before a stream is actively in use, or well after a
+        stream is closed.
+
+        .. warning:: RFC 7540 allows for servers to change the priority of
+                     streams. However, hyper-h2 **does not** allow server
+                     stacks to do this. This is because most clients do not
+                     adequately know how to respond when provided conflicting
+                     priority information, and relatively little utility is
+                     provided by making that functionality available.
+
+        .. note:: hyper-h2 **does not** maintain any information about the
+                  RFC 7540 priority tree. That means that hyper-h2 does not
+                  prevent incautious users from creating invalid priority
+                  trees, particularly by creating priority loops. While some
+                  basic error checking is provided by hyper-h2, users are
+                  strongly recommended to understand their prioritisation
+                  strategies before using the priority tools here.
+
+        .. note:: Priority information is strictly advisory. Servers are
+                  allowed to disregard it entirely. Avoid relying on the idea
+                  that your priority signaling will definitely be obeyed.
+
+        .. versionadded:: 2.4.0
+
+        :param stream_id: The ID of the stream to prioritize.
+        :type stream_id: ``int``
+
+        :param weight: The weight to give the stream. Defaults to ``16``, the
+             default weight of any stream. May be any value between ``1`` and
+             ``256`` inclusive. The relative weight of a stream indicates what
+             proportion of available resources will be allocated to that
+             stream.
+        :type weight: ``int``
+
+        :param depends_on: The ID of the stream on which this stream depends.
+             This stream will only be progressed if it is impossible to
+             progress the parent stream (the one on which this one depends).
+             Passing the value ``0`` means that this stream does not depend on
+             any other. Defaults to ``0``.
+        :type depends_on: ``int``
+
+        :param exclusive: Whether this stream is an exclusive dependency of its
+            "parent" stream (i.e. the stream given by ``depends_on``). If a
+            stream is an exclusive dependency of another, that means that all
+            previously-set children of the parent are moved to become children
+            of the new exclusively-dependent stream. Defaults to ``False``.
+        :type exclusive: ``bool``
+        """
+        self.state_machine.process_input(
+            ConnectionInputs.SEND_PRIORITY
+        )
+
+        # A stream may not depend on itself.
+        if depends_on == stream_id:
+            raise ProtocolError(
+                "Stream %d may not depend on itself" % stream_id
+            )
+
+        # Weight must be between 1 and 256.
+        if weight > 256 or weight < 1:
+            raise ProtocolError(
+                "Weight must be between 1 and 256, not %d" % weight
+            )
+
+        frame = PriorityFrame()
+        frame.stream_id = stream_id
+        frame.exclusive = exclusive
+        frame.depends_on = depends_on
+
+        # Weight is an integer between 1 and 256, but the byte only allows 0
+        # to 255: subtract one.
+        frame.weight = weight - 1
+
+        self._prepare_for_sending([frame])
+
     def local_flow_control_window(self, stream_id):
         """
         Returns the maximum amount of data that can be sent on stream

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -27,7 +27,7 @@ from .events import (
 from .exceptions import (
     ProtocolError, NoSuchStreamError, FlowControlError, FrameTooLargeError,
     TooManyStreamsError, StreamClosedError, StreamIDTooLowError,
-    NoAvailableStreamIDError, UnsupportedFrameError
+    NoAvailableStreamIDError, UnsupportedFrameError, RFC1122Error
 )
 from .frame_buffer import FrameBuffer
 from .settings import (
@@ -716,6 +716,9 @@ class H2Connection(object):
         )
 
         if priority_present:
+            if not self.client_side:
+                raise RFC1122Error("Servers SHOULD NOT prioritize streams.")
+
             headers_frame = frames[0]
             headers_frame.flags.add('PRIORITY')
             frames[0] = _add_frame_priority(
@@ -1104,6 +1107,9 @@ class H2Connection(object):
             of the new exclusively-dependent stream. Defaults to ``False``.
         :type exclusive: ``bool``
         """
+        if not self.client_side:
+            raise RFC1122Error("Servers SHOULD NOT prioritize streams.")
+
         self.state_machine.process_input(
             ConnectionInputs.SEND_PRIORITY
         )

--- a/h2/exceptions.py
+++ b/h2/exceptions.py
@@ -153,3 +153,18 @@ class UnsupportedFrameError(ProtocolError, KeyError):
     """
     # TODO: Remove the KeyError in 3.0.0
     pass
+
+
+class RFC1122Error(H2Error):
+    """
+    Emitted when users attempt to do something that is literally allowed by the
+    relevant RFC, but is sufficiently ill-defined that it's unwise to allow
+    users to actually do it.
+
+    While there is some disagreement about whether or not we should be liberal
+    in what accept, it is a truth universally acknowledged that we should be
+    conservative in what emit.
+    """
+    # shazow says I'm going to regret naming the exception this way. If that
+    # turns out to be true, TELL HIM NOTHING.
+    pass

--- a/h2/exceptions.py
+++ b/h2/exceptions.py
@@ -164,6 +164,8 @@ class RFC1122Error(H2Error):
     While there is some disagreement about whether or not we should be liberal
     in what accept, it is a truth universally acknowledged that we should be
     conservative in what emit.
+
+    .. versionadded:: 2.4.0
     """
     # shazow says I'm going to regret naming the exception this way. If that
     # turns out to be true, TELL HIM NOTHING.

--- a/test/test_priority.py
+++ b/test/test_priority.py
@@ -113,3 +113,116 @@ class TestPriority(object):
             error_code=h2.errors.PROTOCOL_ERROR,
         )
         assert c.data_to_send() == expected_frame.serialize()
+
+    @pytest.mark.parametrize(
+        'depends_on,weight,exclusive',
+        [
+            (0, 256, False),
+            (3, 128, False),
+            (3, 128, True),
+        ]
+    )
+    def test_can_prioritize_stream(self, depends_on, weight, exclusive,
+                                   frame_factory):
+        """
+        hyper-h2 can emit priority frames.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_connection()
+
+        c.send_headers(headers=self.example_request_headers, stream_id=1)
+        c.send_headers(headers=self.example_request_headers, stream_id=3)
+        c.clear_outbound_data_buffer()
+
+        c.prioritize(
+            stream_id=1,
+            depends_on=depends_on,
+            weight=weight,
+            exclusive=exclusive
+        )
+
+        f = frame_factory.build_priority_frame(
+            stream_id=1,
+            weight=weight - 1,
+            depends_on=depends_on,
+            exclusive=exclusive,
+        )
+        assert c.data_to_send() == f.serialize()
+
+    @pytest.mark.parametrize(
+        'depends_on,weight,exclusive',
+        [
+            (0, 256, False),
+            (1, 128, False),
+            (1, 128, True),
+        ]
+    )
+    def test_emit_headers_with_priority_info(self, depends_on, weight,
+                                             exclusive, frame_factory):
+        """
+        It is possible to send a headers frame with priority information on
+        it.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_connection()
+        c.clear_outbound_data_buffer()
+
+        c.send_headers(
+            headers=self.example_request_headers,
+            stream_id=3,
+            priority_weight=weight,
+            priority_depends_on=depends_on,
+            priority_exclusive=exclusive,
+        )
+
+        f = frame_factory.build_headers_frame(
+            headers=self.example_request_headers,
+            stream_id=3,
+            flags=['PRIORITY'],
+            stream_weight=weight - 1,
+            depends_on=depends_on,
+            exclusive=exclusive,
+        )
+        assert c.data_to_send() == f.serialize()
+
+    def test_may_not_prioritize_stream_to_depend_on_self(self, frame_factory):
+        """
+        A stream adjusted to depend on itself causes a Protocol Error.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_connection()
+        c.receive_data(frame_factory.preamble())
+        c.send_headers(
+            headers=self.example_request_headers,
+            stream_id=3,
+            priority_weight=255,
+            priority_depends_on=0,
+            priority_exclusive=False,
+        )
+        c.clear_outbound_data_buffer()
+
+        with pytest.raises(h2.exceptions.ProtocolError):
+            c.prioritize(
+                stream_id=3,
+                depends_on=3,
+            )
+
+        assert not c.data_to_send()
+
+    def test_may_not_initially_set_stream_depend_on_self(self, frame_factory):
+        """
+        A stream that starts by depending on itself causes a Protocol Error.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_connection()
+        c.receive_data(frame_factory.preamble())
+        c.clear_outbound_data_buffer()
+
+        with pytest.raises(h2.exceptions.ProtocolError):
+            c.send_headers(
+                headers=self.example_request_headers,
+                stream_id=3,
+                priority_depends_on=3,
+            )
+
+        assert not c.data_to_send()


### PR DESCRIPTION
Resolves #229.

/cc @Kriechi 

I'm a bit nervous about the fact that the kwargs are different in `send_headers` and `prioritize`, but otherwise I think this is ok.