### PR TITLE
Run Travis in a single test script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,4 @@ install:
   - "pip install flake8"
 before_script: "flake8 --max-complexity 10 h2 test"
 script:
-  - >
-      if [[ $TRAVIS_PYTHON_VERSION == pypy ]]; then
-        py.test test/
-      else
-        coverage run -m py.test test/
-        coverage combine
-        coverage report
-      fi
+  - ./.travis/run.sh

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [[ $TRAVIS_PYTHON_VERSION == pypy ]]; then
+    py.test test/
+else
+    coverage run -m py.test test/
+    coverage combine
+    coverage report
+fi

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -933,12 +933,16 @@ class H2Connection(object):
         :param error_code: (optional) The error code to send in the GOAWAY
             frame.
         :param additional_data: (optional) Additional debug data indicating
-            a reason for closing the connection.
+            a reason for closing the connection. Must be a bytestring.
         :param last_stream_id: (optional) The last stream which was processed
             by the sender. Defaults to ``highest_inbound_stream_id``.
         :returns: Nothing
         """
         self.state_machine.process_input(ConnectionInputs.SEND_GOAWAY)
+
+        # Additional_data must be bytes
+        if additional_data is not None:
+            assert isinstance(additional_data, bytes)
 
         if last_stream_id is None:
             last_stream_id = self.highest_inbound_stream_id

--- a/test/test_basic_logic.py
+++ b/test/test_basic_logic.py
@@ -880,7 +880,7 @@ class TestBasicServer(object):
     @pytest.mark.parametrize("additional_data,output", [
         (None, b''),
         (b'', b''),
-        ('foobar', b'foobar')
+        (b'foobar', b'foobar')
     ])
     def test_close_connection_with_additional_data(self, frame_factory,
                                                    additional_data, output):


### PR DESCRIPTION
Turns out our tests have been failing on Python 3 for quite a while, and we failed to notice because Travis wasn't failing early. Let's change Travis to do the right thing, and then fix the scripts.