### PR TITLE
[RFC] Implement "related events" API.

### DIFF
--- a/h2/events.py
+++ b/h2/events.py
@@ -23,6 +23,9 @@ class RequestReceived(object):
     .. versionchanged:: 2.3.0
        Changed the type of ``headers`` to :class:`HeaderTuple
        <hpack:hpack.HeaderTuple>`. This has no effect on current users.
+
+    .. versionchanged:: 2.4.0
+       Added ``related_events`` property.
     """
     def __init__(self):
         #: The Stream ID for the stream this request was made on.
@@ -30,6 +33,13 @@ class RequestReceived(object):
 
         #: The request headers.
         self.headers = None
+
+        #: Any events "related" to this one: that is, any events that occurred
+        #: at the exact same time as this one because their data was carried on
+        #: the same frame. All of these events need to be processed at once.
+        #:
+        #: .. versionadded:: 2.4.0
+        self.related_events = frozenset()
 
     def __repr__(self):
         return "<RequestReceived stream_id:%s, headers:%s>" % (
@@ -46,6 +56,9 @@ class ResponseReceived(object):
     .. versionchanged:: 2.3.0
        Changed the type of ``headers`` to :class:`HeaderTuple
        <hpack:hpack.HeaderTuple>`. This has no effect on current users.
+
+    .. versionchanged:: 2.4.0
+       Added ``related_events`` property.
     """
     def __init__(self):
         #: The Stream ID for the stream this response was made on.
@@ -53,6 +66,13 @@ class ResponseReceived(object):
 
         #: The response headers.
         self.headers = None
+
+        #: Any events "related" to this one: that is, any events that occurred
+        #: at the exact same time as this one because their data was carried on
+        #: the same frame. All of these events need to be processed at once.
+        #:
+        #: .. versionadded:: 2.4.0
+        self.related_events = frozenset()
 
     def __repr__(self):
         return "<ResponseReceived stream_id:%s, headers:%s>" % (
@@ -72,6 +92,9 @@ class TrailersReceived(object):
     .. versionchanged:: 2.3.0
        Changed the type of ``headers`` to :class:`HeaderTuple
        <hpack:hpack.HeaderTuple>`. This has no effect on current users.
+
+   .. versionchanged:: 2.4.0
+       Added ``related_events`` property.
     """
     def __init__(self):
         #: The Stream ID for the stream on which these trailers were received.
@@ -79,6 +102,13 @@ class TrailersReceived(object):
 
         #: The trailers themselves.
         self.headers = None
+
+        #: Any events "related" to this one: that is, any events that occurred
+        #: at the exact same time as this one because their data was carried on
+        #: the same frame. All of these events need to be processed at once.
+        #:
+        #: .. versionadded:: 2.4.0
+        self.related_events = frozenset()
 
     def __repr__(self):
         return "<TrailersReceived stream_id:%s, headers:%s>" % (
@@ -104,6 +134,9 @@ class InformationalResponseReceived(object):
     .. versionchanged:: 2.3.0
        Changed the type of ``headers`` to :class:`HeaderTuple
        <hpack:hpack.HeaderTuple>`. This has no effect on current users.
+
+    .. versionchanged:: 2.4.0
+        Added ``related_events`` property.
     """
     def __init__(self):
         #: The Stream ID for the stream this informational response was made
@@ -112,6 +145,13 @@ class InformationalResponseReceived(object):
 
         #: The headers for this informational response.
         self.headers = None
+
+        #: Any events "related" to this one: that is, any events that occurred
+        #: at the exact same time as this one because their data was carried on
+        #: the same frame. All of these events need to be processed at once.
+        #:
+        #: .. versionadded:: 2.4.0
+        self.related_events = frozenset()
 
     def __repr__(self):
         return "<InformationalResponseReceived stream_id:%s, headers:%s>" % (
@@ -124,6 +164,9 @@ class DataReceived(object):
     The DataReceived event is fired whenever data is received on a stream from
     the remote peer. The event carries the data itself, and the stream ID on
     which the data was received.
+
+    .. versionchanged:: 2.4.0
+        Added ``related_events`` property.
     """
     def __init__(self):
         #: The Stream ID for the stream this data was received on.
@@ -137,6 +180,13 @@ class DataReceived(object):
         #: when adjusting flow control you should always use this field rather
         #: than ``len(data)``.
         self.flow_controlled_length = None
+
+        #: Any events "related" to this one: that is, any events that occurred
+        #: at the exact same time as this one because their data was carried on
+        #: the same frame. All of these events need to be processed at once.
+        #:
+        #: .. versionadded:: 2.4.0
+        self.related_events = frozenset()
 
     def __repr__(self):
         return (
@@ -243,10 +293,20 @@ class StreamEnded(object):
     The StreamEnded event is fired whenever a stream is ended by a remote
     party. The stream may not be fully closed if it has not been closed
     locally, but no further data or headers should be expected on that stream.
+
+    .. versionchanged:: 2.4.0
+        Added ``related_events`` property.
     """
     def __init__(self):
         #: The Stream ID of the stream that was closed.
         self.stream_id = None
+
+        #: Any events "related" to this one: that is, any events that occurred
+        #: at the exact same time as this one because their data was carried on
+        #: the same frame. All of these events need to be processed at once.
+        #:
+        #: .. versionadded:: 2.4.0
+        self.related_events = frozenset()
 
     def __repr__(self):
         return "<StreamEnded stream_id:%s>" % self.stream_id
@@ -333,6 +393,9 @@ class PriorityUpdated(object):
     This event is purely advisory, and does not need to be acted on.
 
     .. versionadded:: 2.0.0
+
+    .. versionchanged:: 2.4.0
+        Added ``related_events`` property.
     """
     def __init__(self):
         #: The ID of the stream whose priority information is being updated.
@@ -349,6 +412,13 @@ class PriorityUpdated(object):
         #: does, this stream should inherit the current children of its new
         #: parent.
         self.exclusive = None
+
+        #: Any events "related" to this one: that is, any events that occurred
+        #: at the exact same time as this one because their data was carried on
+        #: the same frame. All of these events need to be processed at once.
+        #:
+        #: .. versionadded:: 2.4.0
+        self.related_events = frozenset()
 
     def __repr__(self):
         return (

--- a/test/test_related_events.py
+++ b/test/test_related_events.py
@@ -1,0 +1,322 @@
+# -*- coding: utf-8 -*-
+"""
+test_related_events.py
+~~~~~~~~~~~~~~~~~~~~~~
+
+Specific tests to validate the "related events" logic used by certain events
+inside hyper-h2.
+"""
+import h2.connection
+import h2.events
+
+
+class TestRelatedEvents(object):
+    """
+    Related events correlate all those events that happen on a single frame.
+    """
+    example_request_headers = [
+        (':authority', 'example.com'),
+        (':path', '/'),
+        (':scheme', 'https'),
+        (':method', 'GET'),
+    ]
+
+    example_response_headers = [
+        (':status', '200'),
+        ('server', 'fake-serv/0.1.0')
+    ]
+
+    informational_response_headers = [
+        (':status', '100'),
+        ('server', 'fake-serv/0.1.0')
+    ]
+
+    example_trailers = [
+        ('another', 'field'),
+    ]
+
+    def test_request_received_related_all(self, frame_factory):
+        """
+        RequestReceived has two possible related events: PriorityUpdated and
+        StreamEnded, all fired when a single HEADERS frame is received.
+        """
+        c = h2.connection.H2Connection(client_side=False)
+        c.initiate_connection()
+        c.receive_data(frame_factory.preamble())
+
+        input_frame = frame_factory.build_headers_frame(
+            headers=self.example_request_headers,
+            flags=['END_STREAM', 'PRIORITY'],
+            stream_weight=15,
+            depends_on=0,
+            exclusive=False,
+        )
+        events = c.receive_data(input_frame.serialize())
+
+        assert len(events) == 3
+        set_events = frozenset(events)
+
+        for event in events:
+            assert isinstance(
+                event,
+                (
+                    h2.events.RequestReceived,
+                    h2.events.PriorityUpdated,
+                    h2.events.StreamEnded,
+                )
+            )
+            assert event.related_events == set_events
+
+    def test_request_received_related_priority(self, frame_factory):
+        """
+        RequestReceived can be related to PriorityUpdated.
+        """
+        c = h2.connection.H2Connection(client_side=False)
+        c.initiate_connection()
+        c.receive_data(frame_factory.preamble())
+
+        input_frame = frame_factory.build_headers_frame(
+            headers=self.example_request_headers,
+            flags=['PRIORITY'],
+            stream_weight=15,
+            depends_on=0,
+            exclusive=False,
+        )
+        events = c.receive_data(input_frame.serialize())
+
+        assert len(events) == 2
+        set_events = frozenset(events)
+
+        for event in events:
+            assert isinstance(
+                event, (h2.events.RequestReceived, h2.events.PriorityUpdated)
+            )
+            assert event.related_events == set_events
+
+    def test_request_received_related_stream_ended(self, frame_factory):
+        """
+        RequestReceived can be related to StreamEnded.
+        """
+        c = h2.connection.H2Connection(client_side=False)
+        c.initiate_connection()
+        c.receive_data(frame_factory.preamble())
+
+        input_frame = frame_factory.build_headers_frame(
+            headers=self.example_request_headers,
+            flags=['END_STREAM'],
+        )
+        events = c.receive_data(input_frame.serialize())
+
+        assert len(events) == 2
+        set_events = frozenset(events)
+
+        for event in events:
+            assert isinstance(
+                event, (h2.events.RequestReceived, h2.events.StreamEnded)
+            )
+            assert event.related_events == set_events
+
+    def test_response_received_related_all(self, frame_factory):
+        """
+        ResponseReceived has two possible related events: PriorityUpdated and
+        StreamEnded, all fired when a single HEADERS frame is received.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_connection()
+        c.send_headers(stream_id=1, headers=self.example_request_headers)
+
+        input_frame = frame_factory.build_headers_frame(
+            headers=self.example_response_headers,
+            flags=['END_STREAM', 'PRIORITY'],
+            stream_weight=15,
+            depends_on=0,
+            exclusive=False,
+        )
+        events = c.receive_data(input_frame.serialize())
+
+        assert len(events) == 3
+        set_events = frozenset(events)
+
+        for event in events:
+            assert isinstance(
+                event,
+                (
+                    h2.events.ResponseReceived,
+                    h2.events.PriorityUpdated,
+                    h2.events.StreamEnded,
+                )
+            )
+            assert event.related_events == set_events
+
+    def test_response_received_related_priority(self, frame_factory):
+        """
+        ResponseReceived can be related to PriorityUpdated.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_connection()
+        c.send_headers(stream_id=1, headers=self.example_request_headers)
+
+        input_frame = frame_factory.build_headers_frame(
+            headers=self.example_response_headers,
+            flags=['PRIORITY'],
+            stream_weight=15,
+            depends_on=0,
+            exclusive=False,
+        )
+        events = c.receive_data(input_frame.serialize())
+
+        assert len(events) == 2
+        set_events = frozenset(events)
+
+        for event in events:
+            assert isinstance(
+                event, (h2.events.ResponseReceived, h2.events.PriorityUpdated)
+            )
+            assert event.related_events == set_events
+
+    def test_response_received_related_stream_ended(self, frame_factory):
+        """
+        ResponseReceived can be related to StreamEnded.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_connection()
+        c.send_headers(stream_id=1, headers=self.example_request_headers)
+
+        input_frame = frame_factory.build_headers_frame(
+            headers=self.example_response_headers,
+            flags=['END_STREAM'],
+        )
+        events = c.receive_data(input_frame.serialize())
+
+        assert len(events) == 2
+        set_events = frozenset(events)
+
+        for event in events:
+            assert isinstance(
+                event, (h2.events.ResponseReceived, h2.events.StreamEnded)
+            )
+            assert event.related_events == set_events
+
+    def test_trailers_received_related_all(self, frame_factory):
+        """
+        TrailersReceived has two possible related events: PriorityUpdated and
+        StreamEnded, all fired when a single HEADERS frame is received.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_connection()
+        c.send_headers(stream_id=1, headers=self.example_request_headers)
+
+        f = frame_factory.build_headers_frame(
+            headers=self.example_response_headers,
+        )
+        c.receive_data(f.serialize())
+
+        input_frame = frame_factory.build_headers_frame(
+            headers=self.example_trailers,
+            flags=['END_STREAM', 'PRIORITY'],
+            stream_weight=15,
+            depends_on=0,
+            exclusive=False,
+        )
+        events = c.receive_data(input_frame.serialize())
+
+        assert len(events) == 3
+        set_events = frozenset(events)
+
+        for event in events:
+            assert isinstance(
+                event,
+                (
+                    h2.events.TrailersReceived,
+                    h2.events.PriorityUpdated,
+                    h2.events.StreamEnded,
+                )
+            )
+            assert event.related_events == set_events
+
+    def test_trailers_received_related_stream_ended(self, frame_factory):
+        """
+        TrailersReceived can be related to StreamEnded by itself.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_connection()
+        c.send_headers(stream_id=1, headers=self.example_request_headers)
+
+        f = frame_factory.build_headers_frame(
+            headers=self.example_response_headers,
+        )
+        c.receive_data(f.serialize())
+
+        input_frame = frame_factory.build_headers_frame(
+            headers=self.example_trailers,
+            flags=['END_STREAM'],
+        )
+        events = c.receive_data(input_frame.serialize())
+
+        assert len(events) == 2
+        set_events = frozenset(events)
+
+        for event in events:
+            assert isinstance(
+                event, (h2.events.TrailersReceived, h2.events.StreamEnded)
+            )
+            assert event.related_events == set_events
+
+    def test_informational_response_received_related_all(self, frame_factory):
+        """
+        InformationalResponseReceived has one possible related event:
+        PriorityUpdated, fired when a single HEADERS frame is received.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_connection()
+        c.send_headers(stream_id=1, headers=self.example_request_headers)
+
+        input_frame = frame_factory.build_headers_frame(
+            headers=self.informational_response_headers,
+            flags=['PRIORITY'],
+            stream_weight=15,
+            depends_on=0,
+            exclusive=False,
+        )
+        events = c.receive_data(input_frame.serialize())
+
+        assert len(events) == 2
+        set_events = frozenset(events)
+
+        for event in events:
+            assert isinstance(
+                event,
+                (
+                    h2.events.InformationalResponseReceived,
+                    h2.events.PriorityUpdated,
+                )
+            )
+            assert event.related_events == set_events
+
+    def test_data_received_related_stream_ended(self, frame_factory):
+        """
+        DataReceived can be related to StreamEnded by itself.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_connection()
+        c.send_headers(stream_id=1, headers=self.example_request_headers)
+
+        f = frame_factory.build_headers_frame(
+            headers=self.example_response_headers,
+        )
+        c.receive_data(f.serialize())
+
+        input_frame = frame_factory.build_data_frame(
+            data=b'some data',
+            flags=['END_STREAM'],
+        )
+        events = c.receive_data(input_frame.serialize())
+
+        assert len(events) == 2
+        set_events = frozenset(events)
+
+        for event in events:
+            assert isinstance(
+                event, (h2.events.DataReceived, h2.events.StreamEnded)
+            )
+            assert event.related_events == set_events


### PR DESCRIPTION
This is a potential solution to #234.

The problem we're trying to address here is twofold. Firstly, users like mitmproxy (represented by @Kriechi and @mhils) have a desire to reproduce frames as accurately as possible when they proxy the connection. This means that it's important to them to tell the difference between the two frame sequence of frames that goes `[HEADERS(END_HEADERS), PRIORITY]` and the one frame one that goes `[HEADERS(PRIORITY, END_HEADERS)]`.

Secondly, we want to begin to introduce to hyper-h2 this notion of events happening "simultaneously": that is, where multiple state transitions happen in such a way that they all occur at the same time, meaning that the user cannot reliably determine the allowed actions unless they have processed all the events that were emitted at that time. Mostly this is a pretty benign issue, but it would be nice to lazily consume events rather than emit them all at once (see #228 for more on this).

That makes this change both an attempt to address the first point cleanly *and* a potential precursor to the second. In essence, you can think of this change as something of a "beta" API for one of the proposed changes in #228.

In this specific change, events that can semantically occur *simultaneously* with each other now carry a `related_events` property. This property is a `frozenset` (immutability is good!) of all the events that occurred simultaneously.

This PR is a RFC because I'm not 100% sure I'm happy with the API as it stands. In particular, there are a few warts that I'd like feedback on.

1. Only some events have `related_events` fields. This is done primarily for clarity (to suggest that only some events can be affected by simultaneity), but it potentially means that code that works with the events gets pretty ugly, because sometimes accessing `event.related_events` will raise an `AttributeError`, based only on `type(event)`. So we may want to add `related_events` to *all* events.
2. `related_events` contains a `frozenset` of *all* the events that occurred at once, meaning that `event in event.related_events` is *always* `True`. That's simple and requires the least work in the lower-level library (which is good, because this is a hot section of code), but it leads to the possibility of surprises if the event is handled incautiously (e.g. if you process `event` and then process `event.related_events` you may process `event` *twice*). So we may want to create different frozensets for each event.

Anyway, I'd like people's feedback on this. @python-hyper/contributors, can I get your input here?