### PR TITLE
[RFC] Alternative approach to "related events".

### DIFF
--- a/h2/connection.py
+++ b/h2/connection.py
@@ -1402,6 +1402,7 @@ class H2Connection(object):
 
         if 'PRIORITY' in frame.flags:
             p_frames, p_events = self._receive_priority_frame(frame)
+            stream_events[0].priority_updated = p_events[0]
             stream_events.extend(p_events)
             assert not p_frames
 

--- a/h2/events.py
+++ b/h2/events.py
@@ -23,6 +23,9 @@ class RequestReceived(object):
     .. versionchanged:: 2.3.0
        Changed the type of ``headers`` to :class:`HeaderTuple
        <hpack:hpack.HeaderTuple>`. This has no effect on current users.
+
+    .. versionchanged:: 2.4.0
+       Added ``stream_ended`` and ``priority_updated`` properties.
     """
     def __init__(self):
         #: The Stream ID for the stream this request was made on.
@@ -30,6 +33,20 @@ class RequestReceived(object):
 
         #: The request headers.
         self.headers = None
+
+        #: If this request also ended the stream, the associated
+        #: :class:`StreamEnded <h2.events.StreamEnded>` event will be available
+        #: here.
+        #:
+        #: .. versionadded:: 2.4.0
+        self.stream_ended = None
+
+        #: If this request also had associated priority information, the
+        #: associated :class:`PriorityUpdated <h2.events.PriorityUpdated>`
+        #: event will be available here.
+        #:
+        #: .. versionadded:: 2.4.0
+        self.priority_updated = None
 
     def __repr__(self):
         return "<RequestReceived stream_id:%s, headers:%s>" % (
@@ -46,6 +63,9 @@ class ResponseReceived(object):
     .. versionchanged:: 2.3.0
        Changed the type of ``headers`` to :class:`HeaderTuple
        <hpack:hpack.HeaderTuple>`. This has no effect on current users.
+
+   .. versionchanged:: 2.4.0
+      Added ``stream_ended`` and ``priority_updated`` properties.
     """
     def __init__(self):
         #: The Stream ID for the stream this response was made on.
@@ -53,6 +73,20 @@ class ResponseReceived(object):
 
         #: The response headers.
         self.headers = None
+
+        #: If this response also ended the stream, the associated
+        #: :class:`StreamEnded <h2.events.StreamEnded>` event will be available
+        #: here.
+        #:
+        #: .. versionadded:: 2.4.0
+        self.stream_ended = None
+
+        #: If this response also had associated priority information, the
+        #: associated :class:`PriorityUpdated <h2.events.PriorityUpdated>`
+        #: event will be available here.
+        #:
+        #: .. versionadded:: 2.4.0
+        self.priority_updated = None
 
     def __repr__(self):
         return "<ResponseReceived stream_id:%s, headers:%s>" % (
@@ -72,6 +106,9 @@ class TrailersReceived(object):
     .. versionchanged:: 2.3.0
        Changed the type of ``headers`` to :class:`HeaderTuple
        <hpack:hpack.HeaderTuple>`. This has no effect on current users.
+
+    .. versionchanged:: 2.4.0
+       Added ``stream_ended`` and ``priority_updated`` properties.
     """
     def __init__(self):
         #: The Stream ID for the stream on which these trailers were received.
@@ -79,6 +116,19 @@ class TrailersReceived(object):
 
         #: The trailers themselves.
         self.headers = None
+
+        #: Trailers always end streams. This property has the associated
+        #: :class:`StreamEnded <h2.events.StreamEnded>` in it.
+        #:
+        #: .. versionadded:: 2.4.0
+        self.stream_ended = None
+
+        #: If the trailers also set associated priority information, the
+        #: associated :class:`PriorityUpdated <h2.events.PriorityUpdated>`
+        #: event will be available here.
+        #:
+        #: .. versionadded:: 2.4.0
+        self.priority_updated = None
 
     def __repr__(self):
         return "<TrailersReceived stream_id:%s, headers:%s>" % (
@@ -104,6 +154,9 @@ class InformationalResponseReceived(object):
     .. versionchanged:: 2.3.0
        Changed the type of ``headers`` to :class:`HeaderTuple
        <hpack:hpack.HeaderTuple>`. This has no effect on current users.
+
+    .. versionchanged:: 2.4.0
+       Added ``priority_updated`` property.
     """
     def __init__(self):
         #: The Stream ID for the stream this informational response was made
@@ -112,6 +165,13 @@ class InformationalResponseReceived(object):
 
         #: The headers for this informational response.
         self.headers = None
+
+        #: If this response also had associated priority information, the
+        #: associated :class:`PriorityUpdated <h2.events.PriorityUpdated>`
+        #: event will be available here.
+        #:
+        #: .. versionadded:: 2.4.0
+        self.priority_updated = None
 
     def __repr__(self):
         return "<InformationalResponseReceived stream_id:%s, headers:%s>" % (
@@ -137,6 +197,13 @@ class DataReceived(object):
         #: when adjusting flow control you should always use this field rather
         #: than ``len(data)``.
         self.flow_controlled_length = None
+
+        #: If this data chunk also completed the stream, the associated
+        #: :class:`StreamEnded <h2.events.StreamEnded>` event will be available
+        #: here.
+        #:
+        #: .. versionadded:: 2.4.0
+        self.stream_ended = None
 
     def __repr__(self):
         return (

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -901,9 +901,11 @@ class H2Stream(object):
         events = self.state_machine.process_input(input_)
 
         if end_stream:
-            events += self.state_machine.process_input(
+            es_events = self.state_machine.process_input(
                 StreamInputs.RECV_END_STREAM
             )
+            events[0].stream_ended = es_events[0]
+            events += es_events
 
         self._initialize_content_length(headers)
 
@@ -926,9 +928,11 @@ class H2Stream(object):
         self._track_content_length(len(data), end_stream)
 
         if end_stream:
-            events += self.state_machine.process_input(
+            es_events = self.state_machine.process_input(
                 StreamInputs.RECV_END_STREAM
             )
+            events[0].stream_ended = es_events[0]
+            events.extend(es_events)
 
         events[0].data = data
         events[0].flow_controlled_length = flow_control_len

--- a/test/test_related_events.py
+++ b/test/test_related_events.py
@@ -1,0 +1,367 @@
+# -*- coding: utf-8 -*-
+"""
+test_related_events.py
+~~~~~~~~~~~~~~~~~~~~~~
+
+Specific tests to validate the "related events" logic used by certain events
+inside hyper-h2.
+"""
+import h2.connection
+import h2.events
+
+
+class TestRelatedEvents(object):
+    """
+    Related events correlate all those events that happen on a single frame.
+    """
+    example_request_headers = [
+        (':authority', 'example.com'),
+        (':path', '/'),
+        (':scheme', 'https'),
+        (':method', 'GET'),
+    ]
+
+    example_response_headers = [
+        (':status', '200'),
+        ('server', 'fake-serv/0.1.0')
+    ]
+
+    informational_response_headers = [
+        (':status', '100'),
+        ('server', 'fake-serv/0.1.0')
+    ]
+
+    example_trailers = [
+        ('another', 'field'),
+    ]
+
+    def test_request_received_related_all(self, frame_factory):
+        """
+        RequestReceived has two possible related events: PriorityUpdated and
+        StreamEnded, all fired when a single HEADERS frame is received.
+        """
+        c = h2.connection.H2Connection(client_side=False)
+        c.initiate_connection()
+        c.receive_data(frame_factory.preamble())
+
+        input_frame = frame_factory.build_headers_frame(
+            headers=self.example_request_headers,
+            flags=['END_STREAM', 'PRIORITY'],
+            stream_weight=15,
+            depends_on=0,
+            exclusive=False,
+        )
+        events = c.receive_data(input_frame.serialize())
+
+        assert len(events) == 3
+        base_event = events[0]
+        other_events = events[1:]
+
+        assert base_event.stream_ended in other_events
+        assert isinstance(base_event.stream_ended, h2.events.StreamEnded)
+        assert base_event.priority_updated in other_events
+        assert isinstance(
+            base_event.priority_updated, h2.events.PriorityUpdated
+        )
+
+    def test_request_received_related_priority(self, frame_factory):
+        """
+        RequestReceived can be related to PriorityUpdated.
+        """
+        c = h2.connection.H2Connection(client_side=False)
+        c.initiate_connection()
+        c.receive_data(frame_factory.preamble())
+
+        input_frame = frame_factory.build_headers_frame(
+            headers=self.example_request_headers,
+            flags=['PRIORITY'],
+            stream_weight=15,
+            depends_on=0,
+            exclusive=False,
+        )
+        events = c.receive_data(input_frame.serialize())
+
+        assert len(events) == 2
+        base_event = events[0]
+        priority_updated_event = events[1]
+
+        assert base_event.priority_updated is priority_updated_event
+        assert base_event.stream_ended is None
+        assert isinstance(
+            base_event.priority_updated, h2.events.PriorityUpdated
+        )
+
+    def test_request_received_related_stream_ended(self, frame_factory):
+        """
+        RequestReceived can be related to StreamEnded.
+        """
+        c = h2.connection.H2Connection(client_side=False)
+        c.initiate_connection()
+        c.receive_data(frame_factory.preamble())
+
+        input_frame = frame_factory.build_headers_frame(
+            headers=self.example_request_headers,
+            flags=['END_STREAM'],
+        )
+        events = c.receive_data(input_frame.serialize())
+
+        assert len(events) == 2
+        base_event = events[0]
+        stream_ended_event = events[1]
+
+        assert base_event.stream_ended is stream_ended_event
+        assert base_event.priority_updated is None
+        assert isinstance(base_event.stream_ended, h2.events.StreamEnded)
+
+    def test_response_received_related_nothing(self, frame_factory):
+        """
+        ResponseReceived is ordinarily related to no events.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_connection()
+        c.send_headers(stream_id=1, headers=self.example_request_headers)
+
+        input_frame = frame_factory.build_headers_frame(
+            headers=self.example_response_headers,
+        )
+        events = c.receive_data(input_frame.serialize())
+
+        assert len(events) == 1
+        base_event = events[0]
+
+        assert base_event.stream_ended is None
+        assert base_event.priority_updated is None
+
+    def test_response_received_related_all(self, frame_factory):
+        """
+        ResponseReceived has two possible related events: PriorityUpdated and
+        StreamEnded, all fired when a single HEADERS frame is received.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_connection()
+        c.send_headers(stream_id=1, headers=self.example_request_headers)
+
+        input_frame = frame_factory.build_headers_frame(
+            headers=self.example_response_headers,
+            flags=['END_STREAM', 'PRIORITY'],
+            stream_weight=15,
+            depends_on=0,
+            exclusive=False,
+        )
+        events = c.receive_data(input_frame.serialize())
+
+        assert len(events) == 3
+        base_event = events[0]
+        other_events = events[1:]
+
+        assert base_event.stream_ended in other_events
+        assert isinstance(base_event.stream_ended, h2.events.StreamEnded)
+        assert base_event.priority_updated in other_events
+        assert isinstance(
+            base_event.priority_updated, h2.events.PriorityUpdated
+        )
+
+    def test_response_received_related_priority(self, frame_factory):
+        """
+        ResponseReceived can be related to PriorityUpdated.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_connection()
+        c.send_headers(stream_id=1, headers=self.example_request_headers)
+
+        input_frame = frame_factory.build_headers_frame(
+            headers=self.example_response_headers,
+            flags=['PRIORITY'],
+            stream_weight=15,
+            depends_on=0,
+            exclusive=False,
+        )
+        events = c.receive_data(input_frame.serialize())
+
+        assert len(events) == 2
+        base_event = events[0]
+        priority_updated_event = events[1]
+
+        assert base_event.priority_updated is priority_updated_event
+        assert base_event.stream_ended is None
+        assert isinstance(
+            base_event.priority_updated, h2.events.PriorityUpdated
+        )
+
+    def test_response_received_related_stream_ended(self, frame_factory):
+        """
+        ResponseReceived can be related to StreamEnded.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_connection()
+        c.send_headers(stream_id=1, headers=self.example_request_headers)
+
+        input_frame = frame_factory.build_headers_frame(
+            headers=self.example_response_headers,
+            flags=['END_STREAM'],
+        )
+        events = c.receive_data(input_frame.serialize())
+
+        assert len(events) == 2
+        base_event = events[0]
+        stream_ended_event = events[1]
+
+        assert base_event.stream_ended is stream_ended_event
+        assert base_event.priority_updated is None
+        assert isinstance(base_event.stream_ended, h2.events.StreamEnded)
+
+    def test_trailers_received_related_all(self, frame_factory):
+        """
+        TrailersReceived has two possible related events: PriorityUpdated and
+        StreamEnded, all fired when a single HEADERS frame is received.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_connection()
+        c.send_headers(stream_id=1, headers=self.example_request_headers)
+
+        f = frame_factory.build_headers_frame(
+            headers=self.example_response_headers,
+        )
+        c.receive_data(f.serialize())
+
+        input_frame = frame_factory.build_headers_frame(
+            headers=self.example_trailers,
+            flags=['END_STREAM', 'PRIORITY'],
+            stream_weight=15,
+            depends_on=0,
+            exclusive=False,
+        )
+        events = c.receive_data(input_frame.serialize())
+
+        assert len(events) == 3
+        base_event = events[0]
+        other_events = events[1:]
+
+        assert base_event.stream_ended in other_events
+        assert isinstance(base_event.stream_ended, h2.events.StreamEnded)
+        assert base_event.priority_updated in other_events
+        assert isinstance(
+            base_event.priority_updated, h2.events.PriorityUpdated
+        )
+
+    def test_trailers_received_related_stream_ended(self, frame_factory):
+        """
+        TrailersReceived can be related to StreamEnded by itself.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_connection()
+        c.send_headers(stream_id=1, headers=self.example_request_headers)
+
+        f = frame_factory.build_headers_frame(
+            headers=self.example_response_headers,
+        )
+        c.receive_data(f.serialize())
+
+        input_frame = frame_factory.build_headers_frame(
+            headers=self.example_trailers,
+            flags=['END_STREAM'],
+        )
+        events = c.receive_data(input_frame.serialize())
+
+        assert len(events) == 2
+        base_event = events[0]
+        stream_ended_event = events[1]
+
+        assert base_event.stream_ended is stream_ended_event
+        assert base_event.priority_updated is None
+        assert isinstance(base_event.stream_ended, h2.events.StreamEnded)
+
+    def test_informational_response_related_nothing(self, frame_factory):
+        """
+        InformationalResponseReceived in the standard case is related to
+        nothing.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_connection()
+        c.send_headers(stream_id=1, headers=self.example_request_headers)
+
+        input_frame = frame_factory.build_headers_frame(
+            headers=self.informational_response_headers,
+        )
+        events = c.receive_data(input_frame.serialize())
+
+        assert len(events) == 1
+        base_event = events[0]
+
+        assert base_event.priority_updated is None
+
+    def test_informational_response_received_related_all(self, frame_factory):
+        """
+        InformationalResponseReceived has one possible related event:
+        PriorityUpdated, fired when a single HEADERS frame is received.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_connection()
+        c.send_headers(stream_id=1, headers=self.example_request_headers)
+
+        input_frame = frame_factory.build_headers_frame(
+            headers=self.informational_response_headers,
+            flags=['PRIORITY'],
+            stream_weight=15,
+            depends_on=0,
+            exclusive=False,
+        )
+        events = c.receive_data(input_frame.serialize())
+
+        assert len(events) == 2
+        base_event = events[0]
+        priority_updated_event = events[1]
+
+        assert base_event.priority_updated is priority_updated_event
+        assert isinstance(
+            base_event.priority_updated, h2.events.PriorityUpdated
+        )
+
+    def test_data_received_normally_relates_to_nothing(self, frame_factory):
+        """
+        A plain DATA frame leads to DataReceieved with no related events.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_connection()
+        c.send_headers(stream_id=1, headers=self.example_request_headers)
+
+        f = frame_factory.build_headers_frame(
+            headers=self.example_response_headers,
+        )
+        c.receive_data(f.serialize())
+
+        input_frame = frame_factory.build_data_frame(
+            data=b'some data',
+        )
+        events = c.receive_data(input_frame.serialize())
+
+        assert len(events) == 1
+        base_event = events[0]
+
+        assert base_event.stream_ended is None
+
+    def test_data_received_related_stream_ended(self, frame_factory):
+        """
+        DataReceived can be related to StreamEnded by itself.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_connection()
+        c.send_headers(stream_id=1, headers=self.example_request_headers)
+
+        f = frame_factory.build_headers_frame(
+            headers=self.example_response_headers,
+        )
+        c.receive_data(f.serialize())
+
+        input_frame = frame_factory.build_data_frame(
+            data=b'some data',
+            flags=['END_STREAM'],
+        )
+        events = c.receive_data(input_frame.serialize())
+
+        assert len(events) == 2
+        base_event = events[0]
+        stream_ended_event = events[1]
+
+        assert base_event.stream_ended is stream_ended_event
+        assert isinstance(base_event.stream_ended, h2.events.StreamEnded)


### PR DESCRIPTION
This is an alternative approach to the "related events" API, as discussed in #234. Another approach is in #238, which should be read for the primary discussion.

This RFC differs from #238 by strictly enumerating the possible related events for each primary event and hanging those events directly off named properties. This API has the advantage that it's extremely explicit: code cannot accidentally misbehave anywhere near as easily as it can with #238. However, it has the disadvantage that it's substantially less extensible: if more related events pop up, it requires additional work to plumb them through in the right places.

Regardless, this is worth looking at. /cc @Kriechi @mhils @python-hyper/contributors 