### PR TITLE
Reject request header blocks with bad :authority/Host headers

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,12 @@ Release History
 2.5.0dev0
 ---------
 
-*No changes yet*.
+Bugfixes
+~~~~~~~~
+
+- Correctly reject request header blocks with neither :authority nor Host
+  headers, or header blocks which contain mismatched :authority and Host
+  headers, per RFC 7540 Section 8.1.2.3.
 
 2.4.0 (2016-07-01)
 ------------------

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -35,7 +35,7 @@ from .settings import (
     MAX_CONCURRENT_STREAMS
 )
 from .stream import H2Stream
-from .utilities import validate_headers, guard_increment_window
+from .utilities import guard_increment_window
 
 
 class ConnectionState(Enum):
@@ -1387,7 +1387,6 @@ class H2Connection(object):
             # compatibility, catch all of them.
             raise ProtocolError("Error decoding header block: %s" % e)
 
-        headers = validate_headers(headers)
         events = self.state_machine.process_input(
             ConnectionInputs.RECV_HEADERS
         )

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -25,7 +25,7 @@ from .exceptions import (
 )
 from .utilities import (
     guard_increment_window, is_informational_response, authority_from_headers,
-    secure_headers
+    secure_headers, validate_headers, HeaderValidationFlags
 )
 
 
@@ -912,6 +912,12 @@ class H2Stream(object):
         if isinstance(events[0], TrailersReceived):
             if not end_stream:
                 raise ProtocolError("Trailers must have END_STREAM set")
+
+        conn_state = HeaderValidationFlags(
+            is_client=self.state_machine.client,
+            is_trailer=isinstance(events[0], TrailersReceived)
+        )
+        headers = validate_headers(headers, conn_state)
 
         if header_encoding:
             headers = list(_decode_headers(headers, header_encoding))

--- a/test/test_basic_logic.py
+++ b/test/test_basic_logic.py
@@ -863,7 +863,8 @@ class TestBasicServer(object):
         """
         c = h2.connection.H2Connection(client_side=False)
         c.receive_data(frame_factory.preamble())
-        headers_frame = frame_factory.build_headers_frame([], stream_id=23)
+        headers_frame = frame_factory.build_headers_frame(
+            [(':authority', 'example.com')], stream_id=23)
         c.receive_data(headers_frame.serialize())
 
         f = frame_factory.build_goaway_frame(


### PR DESCRIPTION
This is a WIP attempt at #245 and #246. So far I’ve done the case where we receive header blocks that don’t work under these rules; I haven’t tried to enforce it for header blocks that we send.

It turns out a lot of the example responses in the tests don’t include these headers – given what was said in the original issue, I’m assuming that was just an oversight?

Specific questions:

* Does it look okay so far?
* What's the appropriate action when we try to send header blocks that don’t meet these rules? Is there a way to auto-fill that information, or should we be raising an exception?
* Since this is part of the HTTP/2 spec, and not a hyper-specific feature, does it need any documentation?