### PR TITLE
Fix example in the getting started

### DIFF
--- a/docs/source/basic-usage.rst
+++ b/docs/source/basic-usage.rst
@@ -437,7 +437,10 @@ signaled the request. Let's define it.
         stream_id = event.stream_id
         conn.send_headers(
             stream_id=stream_id,
-            headers={':status': '200', 'server': 'basic-h2-server/1.0'},
+            headers=OrderedDict([
+                (':status', '200'), 
+                ('server', 'basic-h2-server/1.0')
+            ]),
         )
         conn.send_data(
             stream_id=stream_id,
@@ -522,6 +525,7 @@ With these changes, your ``h2server.py`` file should look like this:
 .. code-block:: python
 
     import socket
+    from collections import OrderedDcit
 
     import h2.connection
     import h2.events
@@ -530,7 +534,10 @@ With these changes, your ``h2server.py`` file should look like this:
         stream_id = event.stream_id
         conn.send_headers(
             stream_id=stream_id,
-            headers={':status': '200', 'server': 'basic-h2-server/1.0'},
+            headers=OrderedDict([
+                (':status', '200'),
+                ('server', 'basic-h2-server/1.0'),
+            ]),
         )
         conn.send_data(
             stream_id=stream_id,
@@ -596,12 +603,12 @@ function to take those headers and encode them as a JSON object. Let's do that:
 
         conn.send_headers(
             stream_id=stream_id,
-            headers={
-                ':status': '200',
-                'server': 'basic-h2-server/1.0',
-                'content-length': str(len(response_data)),
-                'content-type': 'application/json',
-            },
+            headers=OrderedDict([
+                (':status', '200'),
+                ('server', 'basic-h2-server/1.0'),
+                ('content-length', str(len(response_data))),
+                ('content-type', 'application/json'),
+            ]),
         )
         conn.send_data(
             stream_id=stream_id,
@@ -634,12 +641,12 @@ file, which should now look like this:
 
         conn.send_headers(
             stream_id=stream_id,
-            headers={
-                ':status': '200',
-                'server': 'basic-h2-server/1.0',
-                'content-length': str(len(response_data)),
-                'content-type': 'application/json',
-            },
+            headers=OrderedDict([
+                (':status', '200'),
+                ('server', 'basic-h2-server/1.0'),
+                ('content-length', str(len(response_data))),
+                ('content-type', 'application/json'),
+            ]),
         )
         conn.send_data(
             stream_id=stream_id,

--- a/docs/source/basic-usage.rst
+++ b/docs/source/basic-usage.rst
@@ -437,10 +437,10 @@ signaled the request. Let's define it.
         stream_id = event.stream_id
         conn.send_headers(
             stream_id=stream_id,
-            headers=OrderedDict([
+            headers=[
                 (':status', '200'), 
                 ('server', 'basic-h2-server/1.0')
-            ]),
+            ],
         )
         conn.send_data(
             stream_id=stream_id,
@@ -525,7 +525,6 @@ With these changes, your ``h2server.py`` file should look like this:
 .. code-block:: python
 
     import socket
-    from collections import OrderedDcit
 
     import h2.connection
     import h2.events
@@ -534,10 +533,10 @@ With these changes, your ``h2server.py`` file should look like this:
         stream_id = event.stream_id
         conn.send_headers(
             stream_id=stream_id,
-            headers=OrderedDict([
+            headers=[
                 (':status', '200'),
                 ('server', 'basic-h2-server/1.0'),
-            ]),
+            ],
         )
         conn.send_data(
             stream_id=stream_id,
@@ -603,12 +602,12 @@ function to take those headers and encode them as a JSON object. Let's do that:
 
         conn.send_headers(
             stream_id=stream_id,
-            headers=OrderedDict([
+            headers=[
                 (':status', '200'),
                 ('server', 'basic-h2-server/1.0'),
                 ('content-length', str(len(response_data))),
                 ('content-type', 'application/json'),
-            ]),
+            ],
         )
         conn.send_data(
             stream_id=stream_id,
@@ -641,12 +640,12 @@ file, which should now look like this:
 
         conn.send_headers(
             stream_id=stream_id,
-            headers=OrderedDict([
+            headers=[
                 (':status', '200'),
                 ('server', 'basic-h2-server/1.0'),
                 ('content-length', str(len(response_data))),
                 ('content-type', 'application/json'),
-            ]),
+            ],
         )
         conn.send_data(
             stream_id=stream_id,


### PR DESCRIPTION
Headers has to be defined with an ordered data structure or it can
happen the `ProtocolError` to be raised by the `_reject_pseudo_header_fields`
procedure (`seen_regular_header` condition). `dict` does not guarantee the
ordering of keys. This can be corrected by implementing `collections.OrderedDict`
or `list`. To not brake the API, I corrected the dictionary into an
ordered dictionary.