### PR TITLE
Fix headers' declaration in 'base-usage.rst' with lists

### DIFF
--- a/docs/source/basic-usage.rst
+++ b/docs/source/basic-usage.rst
@@ -437,7 +437,10 @@ signaled the request. Let's define it.
         stream_id = event.stream_id
         conn.send_headers(
             stream_id=stream_id,
-            headers={':status': '200', 'server': 'basic-h2-server/1.0'},
+            headers=[
+                (':status', '200'), 
+                ('server', 'basic-h2-server/1.0')
+            ],
         )
         conn.send_data(
             stream_id=stream_id,
@@ -530,7 +533,10 @@ With these changes, your ``h2server.py`` file should look like this:
         stream_id = event.stream_id
         conn.send_headers(
             stream_id=stream_id,
-            headers={':status': '200', 'server': 'basic-h2-server/1.0'},
+            headers=[
+                (':status', '200'), 
+                ('server', 'basic-h2-server/1.0')
+            ],
         )
         conn.send_data(
             stream_id=stream_id,
@@ -596,12 +602,12 @@ function to take those headers and encode them as a JSON object. Let's do that:
 
         conn.send_headers(
             stream_id=stream_id,
-            headers={
-                ':status': '200',
-                'server': 'basic-h2-server/1.0',
-                'content-length': str(len(response_data)),
-                'content-type': 'application/json',
-            },
+            headers=[
+                (':status', '200'),
+                ('server', 'basic-h2-server/1.0'),
+                ('content-length', str(len(response_data))),
+                ('content-type', 'application/json'),
+            ],
         )
         conn.send_data(
             stream_id=stream_id,
@@ -634,12 +640,12 @@ file, which should now look like this:
 
         conn.send_headers(
             stream_id=stream_id,
-            headers={
-                ':status': '200',
-                'server': 'basic-h2-server/1.0',
-                'content-length': str(len(response_data)),
-                'content-type': 'application/json',
-            },
+            headers=[
+                (':status', '200'),
+                ('server', 'basic-h2-server/1.0'),
+                ('content-length', str(len(response_data))),
+                ('content-type', 'application/json'),
+            ],
         )
         conn.send_data(
             stream_id=stream_id,


### PR DESCRIPTION
Headers has to be declared as lists instead of dictionaries, because
of the decision of deprecating entirely dictionaries usage.