### PR TITLE
Reject sent header blocks with bad :authority/Host headers

### DIFF
--- a/h2/config.py
+++ b/h2/config.py
@@ -32,19 +32,19 @@ class H2Configuration(object):
         ``False`` or the empty string.
     :type header_encoding: ``str``, ``False``, or ``None``
 
-    :param validate_outbound_headers: Controls whether the headers emitted
+    :param validate_sent_headers: Controls whether the headers emitted
         by this object are validated against the rules in RFC 7540.
         Disabling this setting will cause outbound header validation to
         be skipped, and allow the object to emit headers that may be illegal
         according to RFC 7540. Defaults to ``True``.
-    :type validate_outbound_headers: ``bool``
+    :type validate_sent_headers: ``bool``
 
-    :param normalize_outbound_headers: Controls whether the headers emitted
+    :param normalize_sent_headers: Controls whether the headers emitted
         by this object are normalized before sending.  Disabling this setting
         will cause outbound header normalization to be skipped, and allow
         the object to emit headers that may be illegal according to
         RFC 7540. Defaults to ``True``.
-    :type normalize_outbound_headers: ``bool``
+    :type normalize_sent_headers: ``bool``
 
     :param validate_inbound_headers: Controls whether the headers received
         by this object are validated against the rules in RFC 7540.
@@ -56,13 +56,13 @@ class H2Configuration(object):
     def __init__(self,
                  client_side=True,
                  header_encoding='utf-8',
-                 validate_outbound_headers=True,
-                 normalize_outbound_headers=True,
+                 validate_sent_headers=True,
+                 normalize_sent_headers=True,
                  validate_inbound_headers=True):
         self._client_side = client_side
         self._header_encoding = header_encoding
-        self._validate_outbound_headers = validate_outbound_headers
-        self._normalize_outbound_headers = normalize_outbound_headers
+        self._validate_sent_headers = validate_sent_headers
+        self._normalize_sent_headers = normalize_sent_headers
         self._validate_inbound_headers = validate_inbound_headers
 
     @property
@@ -108,42 +108,42 @@ class H2Configuration(object):
         self._header_encoding = value
 
     @property
-    def validate_outbound_headers(self):
+    def validate_sent_headers(self):
         """
         Whether the headers emitted by this object are validated against
         the rules in RFC 7540. Disabling this setting will cause outbound
         header validation to be skipped, and allow the object to emit headers
         that may be illegal according to RFC 7540. Defaults to ``True``.
         """
-        return self._validate_outbound_headers
+        return self._validate_sent_headers
 
-    @validate_outbound_headers.setter
-    def validate_outbound_headers(self, value):
+    @validate_sent_headers.setter
+    def validate_sent_headers(self, value):
         """
         Enforces validation of outbound headers.
         """
         if not isinstance(value, bool):
-            raise ValueError("validate_outbound_headers must be a bool")
-        self._validate_outbound_headers = value
+            raise ValueError("validate_sent_headers must be a bool")
+        self._validate_sent_headers = value
 
     @property
-    def normalize_outbound_headers(self):
+    def normalize_sent_headers(self):
         """
         Whether the headers emitted by this object are normalized before
         sending.  Disabling this setting will cause outbound header
         normalization to be skipped, and allow the object to emit headers
         that may be illegal according to RFC 7540. Defaults to ``True``.
         """
-        return self._normalize_outbound_headers
+        return self._normalize_sent_headers
 
-    @normalize_outbound_headers.setter
-    def normalize_outbound_headers(self, value):
+    @normalize_sent_headers.setter
+    def normalize_sent_headers(self, value):
         """
         Enforces normalization of outbound headers.
         """
         if not isinstance(value, bool):
-            raise ValueError("normalize_outbound_headers must be a bool")
-        self._normalize_outbound_headers = value
+            raise ValueError("normalize_sent_headers must be a bool")
+        self._normalize_sent_headers = value
 
     @property
     def validate_inbound_headers(self):

--- a/h2/config.py
+++ b/h2/config.py
@@ -31,10 +31,39 @@ class H2Configuration(object):
         to force them to be returned as bytestrings), this can be set to
         ``False`` or the empty string.
     :type header_encoding: ``str``, ``False``, or ``None``
+
+    :param validate_outbound_headers: Controls whether the headers emitted
+        by this object are validated against the rules in RFC 7540.
+        Disabling this setting will cause outbound header validation to
+        be skipped, and allow the object to emit headers that may be illegal
+        according to RFC 7540. Defaults to ``True``.
+    :type validate_outbound_headers: ``bool``
+
+    :param normalize_outbound_headers: Controls whether the headers emitted
+        by this object are normalized before sending.  Disabling this setting
+        will cause outbound header normalization to be skipped, and allow
+        the object to emit headers that may be illegal according to
+        RFC 7540. Defaults to ``True``.
+    :type normalize_outbound_headers: ``bool``
+
+    :param validate_inbound_headers: Controls whether the headers received
+        by this object are validated against the rules in RFC 7540.
+        Disabling this setting will cause inbound header validation to
+        be skipped, and allow the object to receive headers that may be illegal
+        according to RFC 7540. Defaults to ``True``.
+    :type validate_inbound_headers: ``bool``
     """
-    def __init__(self, client_side=True, header_encoding='utf-8'):
+    def __init__(self,
+                 client_side=True,
+                 header_encoding='utf-8',
+                 validate_outbound_headers=True,
+                 normalize_outbound_headers=True,
+                 validate_inbound_headers=True):
         self._client_side = client_side
         self._header_encoding = header_encoding
+        self._validate_outbound_headers = validate_outbound_headers
+        self._normalize_outbound_headers = normalize_outbound_headers
+        self._validate_inbound_headers = validate_inbound_headers
 
     @property
     def client_side(self):
@@ -77,3 +106,61 @@ class H2Configuration(object):
         if value is True:
             raise ValueError("header_encoding cannot be True")
         self._header_encoding = value
+
+    @property
+    def validate_outbound_headers(self):
+        """
+        Whether the headers emitted by this object are validated against
+        the rules in RFC 7540. Disabling this setting will cause outbound
+        header validation to be skipped, and allow the object to emit headers
+        that may be illegal according to RFC 7540. Defaults to ``True``.
+        """
+        return self._validate_outbound_headers
+
+    @validate_outbound_headers.setter
+    def validate_outbound_headers(self, value):
+        """
+        Enforces validation of outbound headers.
+        """
+        if not isinstance(value, bool):
+            raise ValueError("validate_outbound_headers must be a bool")
+        self._validate_outbound_headers = value
+
+    @property
+    def normalize_outbound_headers(self):
+        """
+        Whether the headers emitted by this object are normalized before
+        sending.  Disabling this setting will cause outbound header
+        normalization to be skipped, and allow the object to emit headers
+        that may be illegal according to RFC 7540. Defaults to ``True``.
+        """
+        return self._normalize_outbound_headers
+
+    @normalize_outbound_headers.setter
+    def normalize_outbound_headers(self, value):
+        """
+        Enforces normalization of outbound headers.
+        """
+        if not isinstance(value, bool):
+            raise ValueError("normalize_outbound_headers must be a bool")
+        self._normalize_outbound_headers = value
+
+    @property
+    def validate_inbound_headers(self):
+        """
+        Whether the headers received by this object are validated against
+        the rules in RFC 7540. Disabling this setting will cause inbound
+        header validation to be skipped, and allow the object to receive
+        headers that may be illegal according to RFC 7540.
+        Defaults to ``True``.
+        """
+        return self._validate_inbound_headers
+
+    @validate_inbound_headers.setter
+    def validate_inbound_headers(self, value):
+        """
+        Enforces validation of inbound headers.
+        """
+        if not isinstance(value, bool):
+            raise ValueError("validate_inbound_headers must be a bool")
+        self._validate_inbound_headers = value

--- a/h2/config.py
+++ b/h2/config.py
@@ -32,19 +32,19 @@ class H2Configuration(object):
         ``False`` or the empty string.
     :type header_encoding: ``str``, ``False``, or ``None``
 
-    :param validate_sent_headers: Controls whether the headers emitted
+    :param validate_outbound_headers: Controls whether the headers emitted
         by this object are validated against the rules in RFC 7540.
         Disabling this setting will cause outbound header validation to
         be skipped, and allow the object to emit headers that may be illegal
         according to RFC 7540. Defaults to ``True``.
-    :type validate_sent_headers: ``bool``
+    :type validate_outbound_headers: ``bool``
 
-    :param normalize_sent_headers: Controls whether the headers emitted
+    :param normalize_outbound_headers: Controls whether the headers emitted
         by this object are normalized before sending.  Disabling this setting
         will cause outbound header normalization to be skipped, and allow
         the object to emit headers that may be illegal according to
         RFC 7540. Defaults to ``True``.
-    :type normalize_sent_headers: ``bool``
+    :type normalize_outbound_headers: ``bool``
 
     :param validate_inbound_headers: Controls whether the headers received
         by this object are validated against the rules in RFC 7540.
@@ -56,13 +56,13 @@ class H2Configuration(object):
     def __init__(self,
                  client_side=True,
                  header_encoding='utf-8',
-                 validate_sent_headers=True,
-                 normalize_sent_headers=True,
+                 validate_outbound_headers=True,
+                 normalize_outbound_headers=True,
                  validate_inbound_headers=True):
         self._client_side = client_side
         self._header_encoding = header_encoding
-        self._validate_sent_headers = validate_sent_headers
-        self._normalize_sent_headers = normalize_sent_headers
+        self._validate_outbound_headers = validate_outbound_headers
+        self._normalize_outbound_headers = normalize_outbound_headers
         self._validate_inbound_headers = validate_inbound_headers
 
     @property
@@ -108,42 +108,42 @@ class H2Configuration(object):
         self._header_encoding = value
 
     @property
-    def validate_sent_headers(self):
+    def validate_outbound_headers(self):
         """
         Whether the headers emitted by this object are validated against
         the rules in RFC 7540. Disabling this setting will cause outbound
         header validation to be skipped, and allow the object to emit headers
         that may be illegal according to RFC 7540. Defaults to ``True``.
         """
-        return self._validate_sent_headers
+        return self._validate_outbound_headers
 
-    @validate_sent_headers.setter
-    def validate_sent_headers(self, value):
+    @validate_outbound_headers.setter
+    def validate_outbound_headers(self, value):
         """
         Enforces validation of outbound headers.
         """
         if not isinstance(value, bool):
-            raise ValueError("validate_sent_headers must be a bool")
-        self._validate_sent_headers = value
+            raise ValueError("validate_outbound_headers must be a bool")
+        self._validate_outbound_headers = value
 
     @property
-    def normalize_sent_headers(self):
+    def normalize_outbound_headers(self):
         """
         Whether the headers emitted by this object are normalized before
         sending.  Disabling this setting will cause outbound header
         normalization to be skipped, and allow the object to emit headers
         that may be illegal according to RFC 7540. Defaults to ``True``.
         """
-        return self._normalize_sent_headers
+        return self._normalize_outbound_headers
 
-    @normalize_sent_headers.setter
-    def normalize_sent_headers(self, value):
+    @normalize_outbound_headers.setter
+    def normalize_outbound_headers(self, value):
         """
         Enforces normalization of outbound headers.
         """
         if not isinstance(value, bool):
-            raise ValueError("normalize_sent_headers must be a bool")
-        self._normalize_sent_headers = value
+            raise ValueError("normalize_outbound_headers must be a bool")
+        self._normalize_outbound_headers = value
 
     @property
     def validate_inbound_headers(self):

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -512,6 +512,7 @@ class H2Connection(object):
             self.remote_settings.initial_window_size
         )
         s.inbound_flow_control_window = self.local_settings.initial_window_size
+        s.config = self.config
 
         self.streams[stream_id] = s
 

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -505,14 +505,13 @@ class H2Connection(object):
                 "Invalid stream ID for peer."
             )
 
-        s = H2Stream(stream_id)
+        s = H2Stream(stream_id, config=self.config)
         s.max_inbound_frame_size = self.max_inbound_frame_size
         s.max_outbound_frame_size = self.max_outbound_frame_size
         s.outbound_flow_control_window = (
             self.remote_settings.initial_window_size
         )
         s.inbound_flow_control_window = self.local_settings.initial_window_size
-        s.config = self.config
 
         self.streams[stream_id] = s
 

--- a/h2/events.py
+++ b/h2/events.py
@@ -136,6 +136,29 @@ class TrailersReceived(object):
         )
 
 
+class _HeadersSent(object):
+    """
+    The _HeadersSent event is fired whenever headers are sent.
+
+    This is an internal event, used to determine validation steps on
+    outgoing header blocks.
+    """
+    pass
+
+
+class _TrailersSent(_HeadersSent):
+    """
+    The _TrailersSent event is fired whenever trailers are sent on a
+    stream. Trailers are a set of headers sent after the body of the
+    request/response, and are used to provide information that wasn't known
+    ahead of time (e.g. content-length).
+
+    This is an internal event, used to determine validation steps on
+    outgoing header blocks.
+    """
+    pass
+
+
 class InformationalResponseReceived(object):
     """
     The InformationalResponseReceived event is fired when an informational

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -25,7 +25,7 @@ from .exceptions import (
 )
 from .utilities import (
     guard_increment_window, is_informational_response, authority_from_headers,
-    secure_headers, validate_headers, HeaderValidationFlags,
+    validate_headers, validate_sent_headers, HeaderValidationFlags,
     extract_method_header
 )
 
@@ -1029,8 +1029,7 @@ class H2Stream(object):
         """
         # We need to lowercase the header names, and to ensure that secure
         # header fields are kept out of compression contexts.
-        headers = _lowercase_header_names(headers)
-        headers = secure_headers(headers)
+        headers = validate_sent_headers(headers, None)
         encoded_headers = encoder.encode(headers)
 
         # Slice into blocks of max_outbound_frame_size. Be careful with this:
@@ -1096,19 +1095,6 @@ class H2Stream(object):
 
             if end_stream and expected != actual:
                 raise InvalidBodyLengthError(expected, actual)
-
-
-def _lowercase_header_names(headers):
-    """
-    Given an iterable of header two-tuples, rebuilds that iterable with the
-    header names lowercased. This generator produces tuples that preserve the
-    original type of the header tuple for tuple and any ``HeaderTuple``.
-    """
-    for header in headers:
-        if isinstance(header, HeaderTuple):
-            yield header.__class__(header[0].lower(), header[1])
-        else:
-            yield (header[0].lower(), header[1])
 
 
 def _decode_headers(headers, encoding):

--- a/h2/utilities.py
+++ b/h2/utilities.py
@@ -317,14 +317,14 @@ def _validate_host_authority_header(headers):
     # an :authority header nor a Host header.
     if not authority_present and not host_present:
         raise ProtocolError(
-            "Request header block must have an :authority or Host header."
+            "Request header block does not have an :authority or Host header."
         )
 
     # If we receive both headers, they should definitely match.
     if authority_present and host_present:
         if authority_header_val != host_header_val:
             raise ProtocolError(
-                "Request header block must have matching :authority and "
+                "Request header block has mismatched :authority and "
                 "Host headers: %r / %r"
                 % (authority_header_val, host_header_val)
             )
@@ -373,7 +373,7 @@ def _check_sent_host_authority_header(headers, hdr_validation_flags):
     return _validate_host_authority_header(headers)
 
 
-def normalize_sent_headers(headers, hdr_validation_flags):
+def normalize_outbound_headers(headers, hdr_validation_flags):
     """
     Normalizes a header sequence that we are about to send.
 
@@ -386,7 +386,7 @@ def normalize_sent_headers(headers, hdr_validation_flags):
     return headers
 
 
-def validate_sent_headers(headers, hdr_validation_flags):
+def validate_outbound_headers(headers, hdr_validation_flags):
     """
     Validates and normalizes a header sequence that we are about to send.
 

--- a/test/test_basic_logic.py
+++ b/test/test_basic_logic.py
@@ -388,7 +388,10 @@ class TestBasicClient(object):
         large_binary_string = b''.join(
             random.choice(all_bytes) for _ in range(0, 256)
         )
-        test_headers = [('key', large_binary_string)]
+        test_headers = [
+            (':authority', 'example.com'),
+            ('key', large_binary_string)
+        ]
         c = h2.connection.H2Connection()
 
         # Greatly shrink the max frame size to force us over.
@@ -436,7 +439,7 @@ class TestBasicClient(object):
         """
         Sending headers using dict is deprecated but still valid.
         """
-        test_headers = {'key': 'value'}
+        test_headers = {':authority': 'example.com', 'key': 'value'}
         c = h2.connection.H2Connection()
 
         pytest.deprecated_call(c.send_headers, 1, test_headers)

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -24,8 +24,8 @@ class TestH2Config(object):
 
     boolean_config_options = [
         'client_side',
-        'validate_outbound_headers',
-        'normalize_outbound_headers',
+        'validate_sent_headers',
+        'normalize_sent_headers',
         'validate_inbound_headers'
     ]
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -22,24 +22,35 @@ class TestH2Config(object):
         assert config.client_side
         assert config.header_encoding == 'utf-8'
 
-    @pytest.mark.parametrize('client_side', [None, 'False', 1])
-    def test_client_side_must_be_bool(self, client_side):
+    boolean_config_options = [
+        'client_side',
+        'validate_outbound_headers',
+        'normalize_outbound_headers',
+        'validate_inbound_headers'
+    ]
+
+    @pytest.mark.parametrize('option_name', boolean_config_options)
+    @pytest.mark.parametrize('value', [None, 'False', 1])
+    def test_boolean_config_options_reject_non_bools(self, option_name, value):
         """
-        The value of the ``client_side`` setting must be a boolean.
+        The boolean config options raise an error if you try to set a value
+        that isn't a boolean.
         """
         config = h2.config.H2Configuration()
 
         with pytest.raises(ValueError):
-            config.client_side = client_side
+            setattr(config, option_name, value)
 
-    @pytest.mark.parametrize('client_side', [True, False])
-    def test_client_side_is_reflected(self, client_side):
+    @pytest.mark.parametrize('option_name', boolean_config_options)
+    @pytest.mark.parametrize('value', [True, False])
+    def test_boolean_config_option_is_reflected(self, option_name, value):
         """
-        The value of ``client_side``, when set, is reflected in the value.
+        The value of the boolean config options, when set, is reflected
+        in the value.
         """
         config = h2.config.H2Configuration()
-        config.client_side = client_side
-        assert config.client_side == client_side
+        setattr(config, option_name, value)
+        assert getattr(config, option_name) == value
 
     @pytest.mark.parametrize('header_encoding', [True, 1, object()])
     def test_header_encoding_must_be_false_str_none(self, header_encoding):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -24,8 +24,8 @@ class TestH2Config(object):
 
     boolean_config_options = [
         'client_side',
-        'validate_sent_headers',
-        'normalize_sent_headers',
+        'validate_outbound_headers',
+        'normalize_outbound_headers',
         'validate_inbound_headers'
     ]
 

--- a/test/test_invalid_headers.py
+++ b/test/test_invalid_headers.py
@@ -157,6 +157,29 @@ class TestSendingInvalidFrameSequences(object):
         c.clear_outbound_data_buffer()
         c.send_headers(1, headers)
 
+    @pytest.mark.parametrize('headers', invalid_header_blocks)
+    def test_headers_event_skip_normalization(self, frame_factory, headers):
+        """
+        If we have ``normalize_sent_headers`` disabled, then all of these
+        invalid header blocks are sent through unmodified.
+        """
+        config = h2.config.H2Configuration(
+            validate_sent_headers=False,
+            normalize_sent_headers=False)
+
+        c = h2.connection.H2Connection(config=config)
+        c.initiate_connection()
+
+        f = frame_factory.build_headers_frame(
+            headers,
+            stream_id=1,
+        )
+
+        # Clear the data, then send headers.
+        c.clear_outbound_data_buffer()
+        c.send_headers(1, headers)
+        assert c.data_to_send() == f.serialize()
+
 
 class TestFilter(object):
     """

--- a/test/test_invalid_headers.py
+++ b/test/test_invalid_headers.py
@@ -89,6 +89,38 @@ class TestInvalidFrameSequences(object):
         assert request_event.headers == headers
 
 
+class TestSendingInvalidFrameSequences(object):
+    """
+    Trying to send invalid header sequences cause ProtocolErrors to
+    be thrown.
+    """
+    base_request_headers = [
+        (':authority', 'example.com'),
+        (':path', '/'),
+        (':scheme', 'https'),
+        (':method', 'GET'),
+        ('user-agent', 'someua/0.0.1'),
+    ]
+    invalid_header_blocks = [
+        base_request_headers + [('host', 'notexample.com')],
+        [header for header in base_request_headers
+         if header[0] != ':authority'],
+    ]
+
+    @pytest.mark.parametrize('headers', invalid_header_blocks)
+    def test_headers_event(self, frame_factory, headers):
+        """
+        Test sending invalid headers raise a ProtocolError.
+        """
+        c = h2.connection.H2Connection()
+        c.initiate_connection()
+
+        # Clear the data, then try to send headers.
+        c.clear_outbound_data_buffer()
+        with pytest.raises(h2.exceptions.ProtocolError):
+            c.send_headers(1, headers)
+
+
 class TestFilter(object):
     """
     Test the filter function directly.
@@ -98,42 +130,49 @@ class TestFilter(object):
     HTTP/2 and so may never hit the function, but it's worth validating that it
     behaves as expected anyway.
     """
-    true_false_combinations = [
-        (True, True),
-        (True, False),
-        (False, True),
-        (False, False),
+    validation_functions = [
+        h2.utilities.validate_headers,
+        h2.utilities.validate_sent_headers
     ]
 
-    @pytest.mark.parametrize('is_client,is_trailer', true_false_combinations)
+    hdr_validation_combos = [
+        h2.utilities.HeaderValidationFlags(is_client, is_trailer)
+        for is_client, is_trailer in [
+            (True, True),
+            (True, False),
+            (False, True),
+            (False, False)
+        ]
+    ]
+
+    @pytest.mark.parametrize('validation_function', validation_functions)
+    @pytest.mark.parametrize('hdr_validation_flags', hdr_validation_combos)
     @given(headers=HEADERS_STRATEGY)
-    def test_range_of_acceptable_outputs(self, headers, is_client, is_trailer):
+    def test_range_of_acceptable_outputs(self,
+                                         headers,
+                                         validation_function,
+                                         hdr_validation_flags):
         """
-        validate_headers either returns the data unchanged or throws a
-        ProtocolError.
+        The header validation functions either return the data unchanged
+        or throw a ProtocolError.
         """
-        hdr_validation_flags = h2.utilities.HeaderValidationFlags(
-            is_client=is_client,
-            is_trailer=is_trailer,
-        )
         try:
-            assert headers == h2.utilities.validate_headers(
-                headers, hdr_validation_flags)
+            assert headers == list(validation_function(
+                headers, hdr_validation_flags))
         except h2.exceptions.ProtocolError:
             assert True
 
-    @pytest.mark.parametrize('is_client,is_trailer', true_false_combinations)
-    def test_invalid_pseudo_headers(self, is_client, is_trailer):
+    @pytest.mark.parametrize('hdr_validation_flags', hdr_validation_combos)
+    def test_invalid_pseudo_headers(self, hdr_validation_flags):
         headers = [(b':custom', b'value')]
-        hdr_validation_flags = h2.utilities.HeaderValidationFlags(
-            is_client=is_client,
-            is_trailer=is_trailer
-        )
         with pytest.raises(h2.exceptions.ProtocolError):
             h2.utilities.validate_headers(headers, hdr_validation_flags)
 
-    @pytest.mark.parametrize('is_client,is_trailer', true_false_combinations)
-    def test_matching_authority_host_headers(self, is_client, is_trailer):
+    @pytest.mark.parametrize('validation_function', validation_functions)
+    @pytest.mark.parametrize('hdr_validation_flags', hdr_validation_combos)
+    def test_matching_authority_host_headers(self,
+                                             validation_function,
+                                             hdr_validation_flags):
         """
         If a header block has :authority and Host headers and they match,
         the headers should pass through unchanged.
@@ -145,10 +184,6 @@ class TestFilter(object):
             (b':method', b'GET'),
             (b'host', b'example.com'),
         ]
-        hdr_validation_flags = h2.utilities.HeaderValidationFlags(
-            is_client=is_client,
-            is_trailer=is_trailer
-        )
         assert headers == h2.utilities.validate_headers(
             headers, hdr_validation_flags)
 

--- a/test/test_invalid_headers.py
+++ b/test/test_invalid_headers.py
@@ -144,11 +144,11 @@ class TestSendingInvalidFrameSequences(object):
     @pytest.mark.parametrize('headers', invalid_header_blocks)
     def test_headers_event_skipping_validation(self, frame_factory, headers):
         """
-        If we have ``validate_sent_headers`` disabled, then all of these
+        If we have ``validate_outbound_headers`` disabled, then all of these
         invalid header blocks are allowed to pass.
         """
         config = h2.config.H2Configuration(
-            validate_sent_headers=False)
+            validate_outbound_headers=False)
 
         c = h2.connection.H2Connection(config=config)
         c.initiate_connection()
@@ -160,12 +160,12 @@ class TestSendingInvalidFrameSequences(object):
     @pytest.mark.parametrize('headers', invalid_header_blocks)
     def test_headers_event_skip_normalization(self, frame_factory, headers):
         """
-        If we have ``normalize_sent_headers`` disabled, then all of these
+        If we have ``normalize_outbound_headers`` disabled, then all of these
         invalid header blocks are sent through unmodified.
         """
         config = h2.config.H2Configuration(
-            validate_sent_headers=False,
-            normalize_sent_headers=False)
+            validate_outbound_headers=False,
+            normalize_outbound_headers=False)
 
         c = h2.connection.H2Connection(config=config)
         c.initiate_connection()
@@ -192,7 +192,7 @@ class TestFilter(object):
     """
     validation_functions = [
         h2.utilities.validate_headers,
-        h2.utilities.validate_sent_headers
+        h2.utilities.validate_outbound_headers
     ]
 
     hdr_validation_combos = [

--- a/test/test_utility_functions.py
+++ b/test/test_utility_functions.py
@@ -157,10 +157,10 @@ class TestGetNextAvailableStreamID(object):
 class TestExtractHeader(object):
 
     example_request_headers = [
-            (':authority', 'example.com'),
-            (':path', '/'),
-            (':scheme', 'https'),
-            (':method', 'GET'),
+        (':authority', 'example.com'),
+        (':path', '/'),
+        (':scheme', 'https'),
+        (':method', 'GET'),
     ]
 
     def test_extract_header_method(self):


### PR DESCRIPTION
Quick something I cooked up in my lunch break.

This continues the work started in #252. Intention is that if the user tries to send :authority or Host headers that don't conform, we should raise an `InvalidHeaderBlock` exception.

For now, I've just refactored the existing send_headers pipeline into `utilities.py`, ready to add the new logic. I'll look at the rest of it this evening/tomorrow.