### PR TITLE
Add configuration object.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,13 @@ Release History
 2.5.0dev0
 ---------
 
+API Changes (Backward-Compatible)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Added a new ``H2Configuration`` object that allows rich configuration of
+  a ``H2Connection``. This object supersedes the prior keyword arguments to the
+  ``H2Connection`` object, which are now deprecated and will be removed in 3.0.
+
 Bugfixes
 ~~~~~~~~
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -19,6 +19,13 @@ Connection
    :members:
 
 
+Configuration
+-------------
+
+.. autoclass:: h2.config.H2Configuration
+   :members:
+
+
 .. _h2-events-api:
 
 Events

--- a/h2/config.py
+++ b/h2/config.py
@@ -9,7 +9,7 @@ Objects for controlling the configuration of the HTTP/2 stack.
 
 class H2Configuration(object):
     """
-    An object that controlls the way a single HTTP/2 connection behaves.
+    An object that controls the way a single HTTP/2 connection behaves.
 
     This object allows the users to customize behaviour. In particular, it
     allows users to enable or disable optional features, or to otherwise handle

--- a/h2/config.py
+++ b/h2/config.py
@@ -60,4 +60,6 @@ class H2Configuration(object):
         """
         if not isinstance(value, (bool, str, type(None))):
             raise ValueError("header_encoding must be bool, string, or None")
+        if value is True:
+            raise ValueError("header_encoding cannot be True")
         self._header_encoding = value

--- a/h2/config.py
+++ b/h2/config.py
@@ -17,6 +17,20 @@ class H2Configuration(object):
 
     This object has very little behaviour of its own: it mostly just ensures
     that configuration is self-consistent.
+
+    :param client_side: Whether this object is to be used on the client side of
+        a connection, or on the server side. Affects the logic used by the
+        state machine, the default settings values, the allowable stream IDs,
+        and several other properties. Defaults to ``True``.
+    :type client_side: ``bool``
+
+    :param header_encoding: Controls whether the headers emitted by this object
+        in events are transparently decoded to ``unicode`` strings, and what
+        encoding is used to do that decoding. For historical reasons, this
+        defaults to ``'utf-8'``. To prevent the decoding of headers (that is,
+        to force them to be returned as bytestrings), this can be set to
+        ``False`` or the empty string.
+    :type header_encoding: ``str``, ``False``, or ``None``
     """
     def __init__(self, client_side=True, header_encoding='utf-8'):
         self._client_side = client_side

--- a/h2/config.py
+++ b/h2/config.py
@@ -18,9 +18,9 @@ class H2Configuration(object):
     This object has very little behaviour of its own: it mostly just ensures
     that configuration is self-consistent.
     """
-    def __init__(self):
-        self._client_side = True
-        self._header_encoding = 'utf-8'
+    def __init__(self, client_side=True, header_encoding='utf-8'):
+        self._client_side = client_side
+        self._header_encoding = header_encoding
 
     @property
     def client_side(self):

--- a/h2/config.py
+++ b/h2/config.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""
+h2/config
+~~~~~~~~~
+
+Objects for controlling the configuration of the HTTP/2 stack.
+"""
+
+
+class H2Configuration(object):
+    """
+    An object that controlls the way a single HTTP/2 connection behaves.
+
+    This object allows the users to customize behaviour. In particular, it
+    allows users to enable or disable optional features, or to otherwise handle
+    various unusual behaviours.
+
+    This object has very little behaviour of its own: it mostly just ensures
+    that configuration is self-consistent.
+    """
+    def __init__(self):
+        self._client_side = True
+        self._header_encoding = 'utf-8'
+
+    @property
+    def client_side(self):
+        """
+        Whether this object is to be used on the client side of a connection,
+        or on the server side. Affects the logic used by the state machine, the
+        default settings values, the allowable stream IDs, and several other
+        properties. Defaults to ``True``.
+        """
+        return self._client_side
+
+    @client_side.setter
+    def client_side(self, value):
+        """
+        Enforces constraints on the client side of the connection.
+        """
+        if not isinstance(value, bool):
+            raise ValueError("client_side must be a bool")
+        self._client_side = value
+
+    @property
+    def header_encoding(self):
+        """
+        Controls whether the headers emitted by this object in events are
+        transparently decoded to ``unicode`` strings, and what encoding is used
+        to do that decoding. For historical reasons, this defaults to
+        ``'utf-8'``. To prevent the decoding of headers (that is, to force them
+        to be returned as bytestrings), this can be set to ``False`` or the
+        empty string.
+        """
+        return self._header_encoding
+
+    @header_encoding.setter
+    def header_encoding(self, value):
+        """
+        Enforces constraints on the value of header encoding.
+        """
+        if not isinstance(value, (bool, str, type(None))):
+            raise ValueError("header_encoding must be bool, string, or None")
+        self._header_encoding = value

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -18,6 +18,7 @@ from hyperframe.frame import (
 from hpack.hpack import Encoder, Decoder
 from hpack.exceptions import HPACKError
 
+from .config import H2Configuration
 from .errors import PROTOCOL_ERROR, REFUSED_STREAM
 from .events import (
     WindowUpdated, RemoteSettingsChanged, PingAcknowledged,
@@ -336,6 +337,12 @@ class H2Connection(object):
         # A private variable to store a sequence of received header frames
         # until completion.
         self._header_frames = []
+
+        # Our configuration object.
+        self._config = H2Configuration(
+            client_side=client_side,
+            header_encoding=header_encoding,
+        )
 
         # Data that needs to be sent.
         self._data_to_send = b''

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -6,7 +6,6 @@ h2/connection
 An implementation of a HTTP/2 connection.
 """
 import base64
-import warnings
 
 from enum import Enum, IntEnum
 

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -6,6 +6,7 @@ h2/connection
 An implementation of a HTTP/2 connection.
 """
 import base64
+import warnings
 
 from enum import Enum, IntEnum
 
@@ -341,13 +342,12 @@ class H2Connection(object):
         #: The configuration for this HTTP/2 connection object.
         #:
         #: .. versionadded:: 2.5.0
-        if config is None:
+        self.config = config
+        if self.config is None:
             self.config = H2Configuration(
                 client_side=client_side,
                 header_encoding=header_encoding,
             )
-        else:
-            self.config = config
 
         # Buffer for incoming data.
         self.incoming_buffer = FrameBuffer(server=not client_side)

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -437,13 +437,6 @@ class H2Connection(object):
         """
         return self.config.client_side
 
-    @client_side.setter
-    def client_side(self, value):
-        """
-        Setter for the client_side config value.
-        """
-        self.config.client_side = value
-
     def _begin_new_stream(self, stream_id, allowed_ids):
         """
         Initiate a new stream.

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -253,10 +253,17 @@ class H2Connection(object):
     .. versionchanged:: 2.3.0
        Added the ``header_encoding`` keyword argument.
 
+    .. versionchanged:: 2.5.0
+       Added the ``config`` keyword argument. Deprecated the ``client_side``
+       and ``header_encoding`` parameters.
+
     :param client_side: Whether this object is to be used on the client side of
         a connection, or on the server side. Affects the logic used by the
         state machine, the default settings values, the allowable stream IDs,
         and several other properties. Defaults to ``True``.
+
+        .. deprecated:: 2.5.0
+
     :type client_side: ``bool``
 
     :param header_encoding: Controls whether the headers emitted by this object
@@ -265,7 +272,18 @@ class H2Connection(object):
         defaults to ``'utf-8'``. To prevent the decoding of headers (that is,
         to force them to be returned as bytestrings), this can be set to
         ``False`` or the empty string.
+
+        .. deprecated:: 2.5.0
+
     :type header_encoding: ``str`` or ``False``
+
+    :param config: The configuration for the HTTP/2 connection. If provided,
+        supersedes the deprecated ``client_side`` and ``header_encoding``
+        values.
+
+        .. versionadded:: 2.5.0
+
+    :type config: :class:`H2Configuration <h2.config.H2Configuration>`
     """
     # The initial maximum outbound frame size. This can be changed by receiving
     # a settings frame.
@@ -281,7 +299,7 @@ class H2Connection(object):
     # The largest acceptable window increment.
     MAX_WINDOW_INCREMENT = 2**31 - 1
 
-    def __init__(self, client_side=True, header_encoding='utf-8'):
+    def __init__(self, client_side=True, header_encoding='utf-8', config=None):
         self.state_machine = H2ConnectionStateMachine()
         self.streams = {}
         self.highest_inbound_stream_id = 0
@@ -323,10 +341,13 @@ class H2Connection(object):
         #: The configuration for this HTTP/2 connection object.
         #:
         #: .. versionadded:: 2.5.0
-        self.config = H2Configuration(
-            client_side=client_side,
-            header_encoding=header_encoding,
-        )
+        if config is None:
+            self.config = H2Configuration(
+                client_side=client_side,
+                header_encoding=header_encoding,
+            )
+        else:
+            self.config = config
 
         # Buffer for incoming data.
         self.incoming_buffer = FrameBuffer(server=not client_side)

--- a/test/test_basic_logic.py
+++ b/test/test_basic_logic.py
@@ -66,6 +66,18 @@ class TestBasicClient(object):
         assert not events
         assert c.data_to_send() == expected_data
 
+    def test_deprecated_properties(self):
+        """
+        We can access the deprecated properties.
+        """
+        config = h2.config.H2Configuration(
+            client_side=False, header_encoding=False
+        )
+        c = h2.connection.H2Connection(config=config)
+
+        assert c.client_side is False
+        assert c.header_encoding is False
+
     def test_sending_headers(self):
         """
         Single headers frames are correctly encoded.

--- a/test/test_basic_logic.py
+++ b/test/test_basic_logic.py
@@ -11,6 +11,7 @@ import sys
 import hyperframe
 import pytest
 
+import h2.config
 import h2.connection
 import h2.errors
 import h2.events
@@ -142,7 +143,8 @@ class TestBasicClient(object):
         When receiving a response, the ResponseReceived event fires with bytes
         headers if the encoding is set appropriately.
         """
-        c = h2.connection.H2Connection(header_encoding=False)
+        config = h2.config.H2Configuration(header_encoding=False)
+        c = h2.connection.H2Connection(config=config)
         c.initiate_connection()
         c.send_headers(1, self.example_request_headers, end_stream=True)
 
@@ -165,7 +167,8 @@ class TestBasicClient(object):
         headers if the encoding is set appropriately, but if this changes then
         the change reflects it.
         """
-        c = h2.connection.H2Connection(header_encoding=False)
+        config = h2.config.H2Configuration(header_encoding=False)
+        c = h2.connection.H2Connection(config=config)
         c.initiate_connection()
         c.send_headers(1, self.example_request_headers, end_stream=True)
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+"""
+test_config
+~~~~~~~~~~~
+
+Test the configuration object.
+"""
+import pytest
+
+import h2.config
+
+
+class TestH2Config(object):
+    """
+    Tests of the H2 config object.
+    """
+    def test_defaults(self):
+        """
+        The default values of the HTTP/2 config object are sensible.
+        """
+        config = h2.config.H2Configuration()
+        assert config.client_side
+        assert config.header_encoding == 'utf-8'
+
+    @pytest.mark.parametrize('client_side', [None, 'False', 1])
+    def test_client_side_must_be_bool(self, client_side):
+        """
+        The value of the ``client_side`` setting must be a boolean.
+        """
+        config = h2.config.H2Configuration()
+
+        with pytest.raises(ValueError):
+            config.client_side = client_side
+
+    @pytest.mark.parametrize('client_side', [True, False])
+    def test_client_side_is_reflected(self, client_side):
+        """
+        The value of ``client_side``, when set, is reflected in the value.
+        """
+        config = h2.config.H2Configuration()
+        config.client_side = client_side
+        assert config.client_side == client_side
+
+    @pytest.mark.parametrize('header_encoding', [True, 1, object()])
+    def test_header_encoding_must_be_false_str_none(self, header_encoding):
+        """
+        The value of the ``header_encoding`` setting must be False, a string,
+        or None.
+        """
+        config = h2.config.H2Configuration()
+
+        with pytest.raises(ValueError):
+            config.header_encoding = header_encoding
+
+    @pytest.mark.parametrize('header_encoding', [False, 'ascii', None])
+    def test_header_encoding_is_reflected(self, header_encoding):
+        """
+        The value of ``header_encoding``, when set, is reflected in the value.
+        """
+        config = h2.config.H2Configuration()
+        config.header_encoding = header_encoding
+        assert config.header_encoding == header_encoding


### PR DESCRIPTION
As discussed in #246, this adds a basic configuration object. The goal here is to resist the proliferation of flags to the HTTP/2 connection object.