### PR TITLE
Remove DeprecationWarning spam.

### DIFF
--- a/h2/stream.py
+++ b/h2/stream.py
@@ -728,12 +728,12 @@ class H2Stream(object):
         # Convert headers to two-tuples.
         # FIXME: The fallback for dictionary headers is to be removed in 3.0.
         try:
+            headers = headers.items()
             warnings.warn(
                 "Implicit conversion of dictionaries to two-tuples for "
                 "headers is deprecated and will be removed in 3.0.",
                 DeprecationWarning
             )
-            headers = headers.items()
         except AttributeError:
             headers = headers
 


### PR DESCRIPTION
Turns out we would issue `DeprecationWarning` *even if* users provided lists of tuples, instead of dicts. Whoops!

The fact that I saw this myself and never had it reported is an indication of how useful `DeprecationWarning`s are.