### PR TITLE
Twisted import fixes

### DIFF
--- a/examples/twisted/head_request.py
+++ b/examples/twisted/head_request.py
@@ -18,7 +18,7 @@ from twisted.internet.ssl import optionsForClientTLS
 from hyperframe.frame import SettingsFrame
 from h2.connection import H2Connection
 from h2.events import (
-    ResponseReceived, DataReceived, RemoteSettingsChanged, StreamEnded,
+    ResponseReceived, DataReceived, StreamEnded,
     StreamReset, SettingsAcknowledged,
 )
 

--- a/examples/twisted/twisted-server.py
+++ b/examples/twisted/twisted-server.py
@@ -14,8 +14,7 @@ import sys
 from OpenSSL import crypto
 from twisted.internet.defer import Deferred, inlineCallbacks
 from twisted.internet.protocol import Protocol, Factory
-from twisted.internet import endpoints
-from twisted.internet import reactor, ssl
+from twisted.internet import endpoints, reactor, ssl
 from h2.connection import H2Connection
 from h2.events import (
     RequestReceived, DataReceived, WindowUpdated


### PR DESCRIPTION
- Remove unused import 
- Club twisted imports from the same module in single line