### PR TITLE
Fix link to Priority lib

### DIFF
--- a/docs/source/advanced-usage.rst
+++ b/docs/source/advanced-usage.rst
@@ -218,4 +218,4 @@ version 3.0 of hyper-h2.
 
 
 .. _RFC 7540: https://tools.ietf.org/html/rfc7540
-.. _an implementation: http://python-hyper/priority/
+.. _an implementation: https://github.com/python-hyper/priority

--- a/docs/source/advanced-usage.rst
+++ b/docs/source/advanced-usage.rst
@@ -218,4 +218,4 @@ version 3.0 of hyper-h2.
 
 
 .. _RFC 7540: https://tools.ietf.org/html/rfc7540
-.. _an implementation: https://github.com/python-hyper/priority
+.. _an implementation: http://python-hyper.org/projects/priority/en/latest/


### PR DESCRIPTION
Not sure if the link is actually broken or if the documentation isn't building correctly, just thought I'd bring it your attention.