### PR TITLE
Tidy up repeated code in h2.config

### DIFF
--- a/h2/config.py
+++ b/h2/config.py
@@ -14,14 +14,15 @@ class _BooleanConfigOption(object):
     """
     def __init__(self, name):
         self.name = name
+        self.attr_name = '_%s' % self.name
 
     def __get__(self, instance, owner):
-        return getattr(instance, '_%s' % self.name)
+        return getattr(instance, self.attr_name)
 
     def __set__(self, instance, value):
         if not isinstance(value, bool):
             raise ValueError("%s must be a bool" % self.name)
-        setattr(instance, '_%s' % self.name, value)
+        setattr(instance, self.attr_name, value)
 
 
 class H2Configuration(object):


### PR DESCRIPTION
Using a descriptor for the boolean config options lets us cut down
on repetitive code for defining new boolean settings.  Also ensure
we actually use the validation code when setting up a new
`H2Configuration` object.

---

Addresses #283. Adding new boolean options is now a single-line change, not a load of copy-and-pasting.