### PR TITLE
Reject outbound header blocks with invalid headers

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -44,10 +44,6 @@ Bugfixes
   ``trailers``, per RFC 7540 Section 8.1.2.2.
 - Correctly refuse to send header blocks with connection-specific headers,
   per RFC 7540 Section 8.1.2.2.
-
-Bugfixes (Breaking)
-~~~~~~~~~~~~~~~~~~~
-
 - Correctly refuse to send header blocks that contain duplicate pseudo-header
   fields, or with pseudo-header fields that appear after ordinary header fields,
   per RFC 7540 Section 8.1.2.1.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -41,9 +41,21 @@ Bugfixes
 - Correctly strip leading/trailing whitespace from header field names and
   values.
 - Correctly refuse to send header blocks with a TE header whose value is not
-  ``trailers``, with connection-specific headers, with duplicate pseudo-header
-  fields, or with pseudo-header fields that appear after an ordinary header
-  field.
+  ``trailers``, per RFC 7540 Section 8.1.2.2.
+- Correctly refuse to send header blocks with connection-specific headers,
+  per RFC 7540 Section 8.1.2.2.
+
+Bugfixes (Breaking)
+~~~~~~~~~~~~~~~~~~~
+
+- Correctly refuse to send header blocks that contain duplicate pseudo-header
+  fields, or with pseudo-header fields that appear after ordinary header fields,
+  per RFC 7540 Section 8.1.2.1.
+
+  This may cause passing a dictionary as the header block to ``send_headers``
+  to throw a ``ProtocolError``, because dictionaries are unordered and so they
+  may trip this check.  Passing dictionaries here is deprecated, and callers
+  should change to using a sequence of 2-tuples as their header blocks.
 
 2.4.0 (2016-07-01)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -40,6 +40,10 @@ Bugfixes
   or trailing whitespace.
 - Correctly strip leading/trailing whitespace from header field names and
   values.
+- Correctly refuse to send header blocks with a TE header whose value is not
+  ``trailers``, with connection-specific headers, with duplicate pseudo-header
+  fields, or with pseudo-header fields that appear after an ordinary header
+  field.
 
 2.4.0 (2016-07-01)
 ------------------

--- a/h2/utilities.py
+++ b/h2/utilities.py
@@ -291,7 +291,7 @@ def _custom_startswith(test_string, bytes_prefix, unicode_prefix):
 def _reject_pseudo_header_fields(headers, hdr_validation_flags):
     """
     Raises a ProtocolError if duplicate pseudo-header fields are found in a
-    header block or if a pseudo-header field arrives in a block after an
+    header block or if a pseudo-header field appears in a block after an
     ordinary header field.
     """
     seen_pseudo_header_fields = set()

--- a/h2/utilities.py
+++ b/h2/utilities.py
@@ -254,7 +254,7 @@ def _reject_te(headers, hdr_validation_flags):
     """
     for header in headers:
         if header[0] in (b'te', u'te'):
-            if header[1].lower().strip() not in (b'trailers', u'trailers'):
+            if header[1].lower() not in (b'trailers', u'trailers'):
                 raise ProtocolError(
                     "Invalid value for Transfer-Encoding header: %s" %
                     header[1]

--- a/test/test_basic_logic.py
+++ b/test/test_basic_logic.py
@@ -439,8 +439,16 @@ class TestBasicClient(object):
         """
         Sending headers using dict is deprecated but still valid.
         """
+        # One of the steps in the outbound header validation logic checks
+        # that we don't send a pseudo-header after we've sent a regular
+        # header.  We can't guarantee that if you send headers as a dict,
+        # because dicts are unordered.
+        config = h2.config.H2Configuration(
+            validate_outbound_headers=False
+        )
+
         test_headers = {':authority': 'example.com', 'key': 'value'}
-        c = h2.connection.H2Connection()
+        c = h2.connection.H2Connection(config=config)
 
         pytest.deprecated_call(c.send_headers, 1, test_headers)
 

--- a/test/test_invalid_headers.py
+++ b/test/test_invalid_headers.py
@@ -127,12 +127,14 @@ class TestSendingInvalidFrameSequences(object):
         ('user-agent', 'someua/0.0.1'),
     ]
     invalid_header_blocks = [
-        base_request_headers + [('te', 'chunked')],
+        base_request_headers + [(':late', 'pseudo-header')],
+        [(':path', 'duplicate-pseudo-header')] + base_request_headers,
         base_request_headers + [('connection', 'close')],
         base_request_headers + [('proxy-connection', 'close')],
         base_request_headers + [('keep-alive', 'close')],
         base_request_headers + [('transfer-encoding', 'gzip')],
         base_request_headers + [('upgrade', 'super-protocol/1.1')],
+        base_request_headers + [('te', 'chunked')],
         base_request_headers + [('host', 'notexample.com')],
         [header for header in base_request_headers
          if header[0] != ':authority'],

--- a/test/test_invalid_headers.py
+++ b/test/test_invalid_headers.py
@@ -127,6 +127,12 @@ class TestSendingInvalidFrameSequences(object):
         ('user-agent', 'someua/0.0.1'),
     ]
     invalid_header_blocks = [
+        base_request_headers + [('te', 'chunked')],
+        base_request_headers + [('connection', 'close')],
+        base_request_headers + [('proxy-connection', 'close')],
+        base_request_headers + [('keep-alive', 'close')],
+        base_request_headers + [('transfer-encoding', 'gzip')],
+        base_request_headers + [('upgrade', 'super-protocol/1.1')],
         base_request_headers + [('host', 'notexample.com')],
         [header for header in base_request_headers
          if header[0] != ':authority'],


### PR DESCRIPTION
There are several rules we use to reject inbound header blocks as
invalid, but we don't enforce them on headers we're sending:

* A Transfer-Encoding header must have value "trailers".
* No blocks should have connection-specific headers.

These are rules mandated by RFC 7540. We already have the code to
police these rules, so apply it to outbound as well as inbound
headers.

Inbound headers always have byte strings for names/values, whereas
we may still have Unicode strings for the outbound headers (they're
encoded after this validation step), so we need to be tolerant
to Unicode headers here.

---

This is a first attempt at tackling #262. (2) and (3) are now enforced on outgoing headers.

Slightly complicated by the Unicode issue, which makes this pipeline a tad slower throughout. Is this is a sensible way to handle it?

I haven’t done the checks for duplicate pseudo-header fields yet, because that’s a bit more complicated. Specifically, we do `if header[0].startswith(b':')`, which only works if `header[0]` is a bytestring. You get a `TypeError` if you call it on a Unicode string. Doesn’t have to be done here, but any suggestions?