### PR TITLE
check for pseudo header in trailer

### DIFF
--- a/h2/utilities.py
+++ b/h2/utilities.py
@@ -322,6 +322,13 @@ def _reject_pseudo_header_fields(headers, hdr_validation_flags):
 
         yield header
 
+    # Pseudo-header fields MUST NOT appear in trailers - RFC 7540 § 8.1.2.1
+    if hdr_validation_flags.is_trailer and seen_pseudo_header_fields:
+        raise ProtocolError(
+            "Received pseudo-header in trailer %s" %
+            seen_pseudo_header_fields
+        )
+
 
 def _validate_host_authority_header(headers):
     """

--- a/test/test_complex_logic.py
+++ b/test/test_complex_logic.py
@@ -90,9 +90,9 @@ class TestComplexClient(object):
             assert c.open_outbound_streams == expected_outbound_streams
 
             # Pushed streams can only be closed remotely.
-            f = frame_factory.build_headers_frame(
+            f = frame_factory.build_data_frame(
                 stream_id=stream_id+1,
-                headers=self.example_response_headers,
+                data=b'the content',
                 flags=['END_STREAM'],
             )
             c.receive_data(f.serialize())


### PR DESCRIPTION
So, I'm quickly realizing that I'm way out of my element here with HTTP2, so please excuse my naivety.

From the quick reading I did, I think this workflow *should* fail with a `ProtocolError`, but currently doesn't. I'm not sure how state works with the connection object here, so it's possible I'm not using the frames correctly.

@Lukasa or @alexwlchan, could I get some confirmation that this is along the right path?