### PR TITLE
Reject response header blocks that don’t include the :status field

### DIFF
--- a/h2/events.py
+++ b/h2/events.py
@@ -146,6 +146,17 @@ class _HeadersSent(object):
     pass
 
 
+class _ResponseHeadersSent(_HeadersSent):
+    """
+    The _ResponseHeadersSent event is fired whenever response headers are sent
+    on a stream.
+
+    This is an internal event, used to determine validation steps on
+    outgoing header blocks.
+    """
+    pass
+
+
 class _TrailersSent(_HeadersSent):
     """
     The _TrailersSent event is fired whenever trailers are sent on a

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -1047,8 +1047,8 @@ class H2Stream(object):
             # Some state changes don't emit an internal event (for example,
             # sending a push promise).  We *always* emit an event for trailers,
             # so the absence of an event means this definitely isn't a trailer.
-            # Similarly, we also emit an event whenever reponse headers are
-            # sent or received. So absent of those events means this is not an
+            # Similarly, we also emit an event whenever response headers are
+            # sent or received. So absence of those events means this is not an
             # response header either.
             #
             # TODO: Find any places where we don't emit anything, and emit

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -766,7 +766,8 @@ class H2Stream(object):
         events = self.state_machine.process_input(input_)
 
         hf = HeadersFrame(self.stream_id)
-        hdr_validation_flags = self._build_hdr_validation_flags(events)
+        hdr_validation_flags = self._build_hdr_validation_flags(
+            events, is_response=not self.state_machine.client)
         frames = self._build_headers_frames(
             headers, encoder, hf, hdr_validation_flags
         )
@@ -1031,7 +1032,7 @@ class H2Stream(object):
 
         return [], events
 
-    def _build_hdr_validation_flags(self, events):
+    def _build_hdr_validation_flags(self, events, is_response=False):
         """
         Constructs a set of header validation flags for use when normalizing
         and validating header blocks.
@@ -1049,9 +1050,12 @@ class H2Stream(object):
             # an internal event, so we can do away with this branch.
             is_trailer = False
 
+        is_response_header = is_response and not is_trailer
+
         return HeaderValidationFlags(
             is_client=self.state_machine.client,
-            is_trailer=is_trailer
+            is_trailer=is_trailer,
+            is_response_header=is_response_header
         )
 
     def _build_headers_frames(self,

--- a/h2/utilities.py
+++ b/h2/utilities.py
@@ -332,14 +332,15 @@ def _reject_pseudo_header_fields(headers, hdr_validation_flags):
     # If ':status' pseudo-header is not there in a response header, reject it
     # Relevant RFC section: RFC 7540 § 8.1.2.4
     # https://tools.ietf.org/html/rfc7540#section-8.1.2.4
-    seen_status_field = (
-        b':status' in seen_pseudo_header_fields or
-        u':status' in seen_pseudo_header_fields
-    )
-    if hdr_validation_flags.is_response_header and not seen_status_field:
-        raise ProtocolError(
-            "Response header block does not have a :status header"
+    if hdr_validation_flags.is_response_header:
+        seen_status_field = (
+            b':status' in seen_pseudo_header_fields or
+            u':status' in seen_pseudo_header_fields
         )
+        if not seen_status_field:
+            raise ProtocolError(
+                "Response header block does not have a :status header"
+            )
 
 
 def _validate_host_authority_header(headers):

--- a/h2/utilities.py
+++ b/h2/utilities.py
@@ -171,7 +171,7 @@ def authority_from_headers(headers):
 # should be applied to a given set of headers.
 HeaderValidationFlags = collections.namedtuple(
     'HeaderValidationFlags',
-    ['is_client', 'is_trailer']
+    ['is_client', 'is_trailer', 'is_response_header']
 )
 
 
@@ -328,6 +328,13 @@ def _reject_pseudo_header_fields(headers, hdr_validation_flags):
             "Received pseudo-header in trailer %s" %
             seen_pseudo_header_fields
         )
+
+    # If ':status' pseudo-header is not there in a response header, reject it
+    if (hdr_validation_flags.is_response_header and
+        not any(field in seen_pseudo_header_fields
+                for field in (b':status', u':status'))):
+        raise ProtocolError(
+            "Couldn't find :status pseudo-header field in response header")
 
 
 def _validate_host_authority_header(headers):

--- a/h2/utilities.py
+++ b/h2/utilities.py
@@ -330,11 +330,14 @@ def _reject_pseudo_header_fields(headers, hdr_validation_flags):
         )
 
     # If ':status' pseudo-header is not there in a response header, reject it
-    if (hdr_validation_flags.is_response_header and
-        not any(field in seen_pseudo_header_fields
-                for field in (b':status', u':status'))):
+    if (
+        hdr_validation_flags.is_response_header and
+        b':status' not in seen_pseudo_header_fields and
+        u':status' not in seen_pseudo_header_fields
+    ):
         raise ProtocolError(
-            "Couldn't find :status pseudo-header field in response header")
+            "Response header block does not have a :status header"
+        )
 
 
 def _validate_host_authority_header(headers):

--- a/h2/utilities.py
+++ b/h2/utilities.py
@@ -330,6 +330,8 @@ def _reject_pseudo_header_fields(headers, hdr_validation_flags):
         )
 
     # If ':status' pseudo-header is not there in a response header, reject it
+    # Relevant RFC section: RFC 7540 § 8.1.2.4
+    # https://tools.ietf.org/html/rfc7540#section-8.1.2.4
     seen_status_field = (
         b':status' in seen_pseudo_header_fields or
         u':status' in seen_pseudo_header_fields

--- a/h2/utilities.py
+++ b/h2/utilities.py
@@ -330,11 +330,11 @@ def _reject_pseudo_header_fields(headers, hdr_validation_flags):
         )
 
     # If ':status' pseudo-header is not there in a response header, reject it
-    if (
-        hdr_validation_flags.is_response_header and
-        b':status' not in seen_pseudo_header_fields and
-        u':status' not in seen_pseudo_header_fields
-    ):
+    seen_status_field = (
+        b':status' in seen_pseudo_header_fields or
+        u':status' in seen_pseudo_header_fields
+    )
+    if hdr_validation_flags.is_response_header and not seen_status_field:
         raise ProtocolError(
             "Response header block does not have a :status header"
         )

--- a/test/test_basic_logic.py
+++ b/test/test_basic_logic.py
@@ -605,7 +605,7 @@ class TestBasicClient(object):
         c = h2.connection.H2Connection()
         c.initiate_connection()
         c.send_headers(1, self.example_request_headers)
-        f = frame_factory.build_headers_frame(self.example_request_headers)
+        f = frame_factory.build_headers_frame(self.example_response_headers)
         c.receive_data(f.serialize())
 
         # Send in trailers.

--- a/test/test_invalid_headers.py
+++ b/test/test_invalid_headers.py
@@ -287,9 +287,9 @@ class TestFilter(object):
     @pytest.mark.parametrize(
         'hdr_validation_flags', hdr_validation_request_headers_no_trailer
     )
-    def test_matching_authority_host_headers(
-        self, validation_function, hdr_validation_flags
-    ):
+    def test_matching_authority_host_headers(self,
+                                             validation_function,
+                                             hdr_validation_flags):
         """
         If a header block has :authority and Host headers and they match,
         the headers should pass through unchanged.

--- a/test/test_invalid_headers.py
+++ b/test/test_invalid_headers.py
@@ -253,8 +253,11 @@ class TestFilter(object):
         filter(lambda flags: flags.is_response_header, hdr_validation_combos)
     )
 
-    hdr_validation_no_trailers = list(
-        filter(lambda flags: not flags.is_trailer, hdr_validation_combos)
+    hdr_validation_request_headers_no_trailer = list(
+        filter(
+            lambda flags: not (flags.is_trailer or flags.is_response_header),
+            hdr_validation_combos
+        )
     )
 
     @pytest.mark.parametrize('validation_function', validation_functions)
@@ -282,11 +285,11 @@ class TestFilter(object):
 
     @pytest.mark.parametrize('validation_function', validation_functions)
     @pytest.mark.parametrize(
-        'hdr_validation_flags', hdr_validation_no_trailers
+        'hdr_validation_flags', hdr_validation_request_headers_no_trailer
     )
-    def test_matching_authority_host_headers(self,
-                                             validation_function,
-                                             hdr_validation_flags):
+    def test_matching_authority_host_headers(
+        self, validation_function, hdr_validation_flags
+    ):
         """
         If a header block has :authority and Host headers and they match,
         the headers should pass through unchanged.
@@ -299,7 +302,8 @@ class TestFilter(object):
             (b'host', b'example.com'),
         ]
         assert headers == h2.utilities.validate_headers(
-            headers, hdr_validation_flags)
+            headers, hdr_validation_flags
+        )
 
     @pytest.mark.parametrize(
         'hdr_validation_flags', hdr_validation_response_headers

--- a/test/test_invalid_headers.py
+++ b/test/test_invalid_headers.py
@@ -249,16 +249,15 @@ class TestFilter(object):
         )
     ]
 
-    hdr_validation_response_headers = list(
-        filter(lambda flags: flags.is_response_header, hdr_validation_combos)
-    )
+    hdr_validation_response_headers = [
+        flags for flags in hdr_validation_combos
+        if flags.is_response_header
+    ]
 
-    hdr_validation_request_headers_no_trailer = list(
-        filter(
-            lambda flags: not (flags.is_trailer or flags.is_response_header),
-            hdr_validation_combos
-        )
-    )
+    hdr_validation_request_headers_no_trailer = [
+        flags for flags in hdr_validation_combos
+        if not (flags.is_trailer or flags.is_response_header)
+    ]
 
     @pytest.mark.parametrize('validation_function', validation_functions)
     @pytest.mark.parametrize('hdr_validation_flags', hdr_validation_combos)

--- a/test/test_invalid_headers.py
+++ b/test/test_invalid_headers.py
@@ -245,7 +245,8 @@ class TestFilter(object):
             is_client, is_trailer, is_response_header
         )
         for is_client, is_trailer, is_response_header in (
-            itertools.product([True, False], repeat=3))
+            itertools.product([True, False], repeat=3)
+        )
     ]
 
     hdr_validation_no_trailers = [
@@ -314,8 +315,9 @@ class TestFilter(object):
         assert headers == h2.utilities.validate_headers(
             headers, hdr_validation_flags)
 
-    @pytest.mark.parametrize('hdr_validation_flags',
-                             hdr_validation_response_headers)
+    @pytest.mark.parametrize(
+        'hdr_validation_flags', hdr_validation_response_headers
+    )
     def test_response_header_without_status(self, hdr_validation_flags):
         headers = [(b'content-length', b'42')]
         with pytest.raises(h2.exceptions.ProtocolError):

--- a/test/test_invalid_headers.py
+++ b/test/test_invalid_headers.py
@@ -249,27 +249,13 @@ class TestFilter(object):
         )
     ]
 
-    hdr_validation_no_trailers = [
-        h2.utilities.HeaderValidationFlags(
-            is_client, is_trailer, is_response_header
-        )
-        for is_client, is_trailer, is_response_header in [
-            (True, False, False),
-            (False, False, False),
-        ]
-    ]
+    hdr_validation_response_headers = list(
+        filter(lambda flags: flags.is_response_header, hdr_validation_combos)
+    )
 
-    hdr_validation_response_headers = [
-        h2.utilities.HeaderValidationFlags(
-            is_client, is_trailer, is_response_header
-        )
-        for is_client, is_trailer, is_response_header in [
-            (True, False, True),
-            (False, True, True),
-            (True, True, True),
-            (False, False, True)
-        ]
-    ]
+    hdr_validation_no_trailers = list(
+        filter(lambda flags: not flags.is_trailer, hdr_validation_combos)
+    )
 
     @pytest.mark.parametrize('validation_function', validation_functions)
     @pytest.mark.parametrize('hdr_validation_flags', hdr_validation_combos)

--- a/test/test_invalid_headers.py
+++ b/test/test_invalid_headers.py
@@ -242,14 +242,16 @@ class TestFilter(object):
 
     hdr_validation_combos = [
         h2.utilities.HeaderValidationFlags(
-            is_client, is_trailer, is_response_header)
+            is_client, is_trailer, is_response_header
+        )
         for is_client, is_trailer, is_response_header in (
             itertools.product([True, False], repeat=3))
     ]
 
     hdr_validation_no_trailers = [
         h2.utilities.HeaderValidationFlags(
-            is_client, is_trailer, is_response_header)
+            is_client, is_trailer, is_response_header
+        )
         for is_client, is_trailer, is_response_header in [
             (True, False, False),
             (False, False, False),
@@ -258,7 +260,8 @@ class TestFilter(object):
 
     hdr_validation_response_headers = [
         h2.utilities.HeaderValidationFlags(
-            is_client, is_trailer, is_response_header)
+            is_client, is_trailer, is_response_header
+        )
         for is_client, is_trailer, is_response_header in [
             (True, False, True),
             (False, True, True),


### PR DESCRIPTION
Fix for #290 