### PR TITLE
Receiving a PUSH_PROMISE from a client is an error

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -56,6 +56,8 @@ Bugfixes
   7540 Section 8.1.2.1.
 - Correctly refuse to send trailers that contain HTTP/2 pseudo-header fields,
   per RFC 7540 Section 8.1.2.1.
+- Correctly reject a PUSH_PROMISE frame sent by a client, per RFC 7540
+  Section 8.2.
 
 
 2.4.0 (2016-07-01)

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -1487,7 +1487,7 @@ class H2Connection(object):
         """
         Receive a push-promise frame on the connection.
         """
-        # A client cannot push. - RFC 7540 § 8.2
+        # A client cannot push - RFC 7540 § 8.2
         if not self.config.client_side:
             raise ProtocolError("Received pushed stream from a client")
 

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -1487,6 +1487,10 @@ class H2Connection(object):
         """
         Receive a push-promise frame on the connection.
         """
+        # A client cannot push. - RFC 7540 § 8.2
+        if not self.config.client_side:
+            raise ProtocolError("Received pushed stream from a client")
+
         if not self.local_settings.enable_push:
             raise ProtocolError("Received pushed stream")
 

--- a/test/test_basic_logic.py
+++ b/test/test_basic_logic.py
@@ -1545,8 +1545,9 @@ class TestBasicServer(object):
         c.receive_data(f1.serialize())
         c.clear_outbound_data_buffer()
 
-        with pytest.raises(h2.exceptions.ProtocolError):
+        with pytest.raises(h2.exceptions.ProtocolError) as excinfo:
             c.receive_data(f2.serialize())
+        excinfo.match('Received pushed stream from a client')
 
         expected_frame = frame_factory.build_goaway_frame(
             1, h2.errors.ErrorCodes.PROTOCOL_ERROR


### PR DESCRIPTION
This is explicitly forbidden in the spec (RFC 7540 § 8.2).

> A client cannot push.  Thus, servers MUST treat the receipt of a
>    PUSH_PROMISE frame as a connection error (Section 5.4.1) of type
>    PROTOCOL_ERROR.

In practice hyper-h2 was already raising a ProtocolError, because
local_settings.enable_push is False for servers.  This commit:
- Tweaks the error message to make it clear that receiving it from
  the client is important.
- Add an explicit test case.
