### PR TITLE
Add `_RequestSent` event

### DIFF
--- a/h2/events.py
+++ b/h2/events.py
@@ -157,6 +157,17 @@ class _ResponseSent(_HeadersSent):
     pass
 
 
+class _RequestSent(_HeadersSent):
+    """
+    The _RequestSent event is fired whenever request headers are sent
+    on a stream.
+
+    This is an internal event, used to determine validation steps on
+    outgoing header blocks.
+    """
+    pass
+
+
 class _TrailersSent(_HeadersSent):
     """
     The _TrailersSent event is fired whenever trailers are sent on a

--- a/h2/events.py
+++ b/h2/events.py
@@ -146,9 +146,9 @@ class _HeadersSent(object):
     pass
 
 
-class _ResponseHeadersSent(_HeadersSent):
+class _ResponseSent(_HeadersSent):
     """
-    The _ResponseHeadersSent event is fired whenever response headers are sent
+    The _ResponseSent event is fired whenever response headers are sent
     on a stream.
 
     This is an internal event, used to determine validation steps on

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -19,7 +19,7 @@ from .events import (
     RequestReceived, ResponseReceived, DataReceived, WindowUpdated,
     StreamEnded, PushedStreamReceived, StreamReset, TrailersReceived,
     InformationalResponseReceived, AlternativeServiceAvailable,
-    _HeadersSent, _ResponseSent, _TrailersSent
+    _HeadersSent, _ResponseSent, _RequestSent, _TrailersSent
 )
 from .exceptions import (
     ProtocolError, StreamClosedError, InvalidBodyLengthError
@@ -133,7 +133,7 @@ class H2StreamStateMachine(object):
         """
         self.client = True
         self.headers_sent = True
-        event = _HeadersSent()
+        event = _RequestSent()
 
         return [event]
 

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -19,7 +19,7 @@ from .events import (
     RequestReceived, ResponseReceived, DataReceived, WindowUpdated,
     StreamEnded, PushedStreamReceived, StreamReset, TrailersReceived,
     InformationalResponseReceived, AlternativeServiceAvailable,
-    _HeadersSent, _ResponseHeadersSent, _TrailersSent
+    _HeadersSent, _ResponseSent, _TrailersSent
 )
 from .exceptions import (
     ProtocolError, StreamClosedError, InvalidBodyLengthError
@@ -146,7 +146,7 @@ class H2StreamStateMachine(object):
             if self.client is True or self.client is None:
                 raise ProtocolError("Client cannot send responses.")
             self.headers_sent = True
-            event = _ResponseHeadersSent()
+            event = _ResponseSent()
         else:
             assert not self.trailers_sent
             self.trailers_sent = True
@@ -1041,7 +1041,7 @@ class H2Stream(object):
                 events[0], (_TrailersSent, TrailersReceived)
             )
             is_response_header = isinstance(
-                events[0], (_ResponseHeadersSent, ResponseReceived)
+                events[0], (_ResponseSent, ResponseReceived)
             )
         except IndexError:
             # Some state changes don't emit an internal event (for example,


### PR DESCRIPTION
This is a quick fix for issue #314, since I was already poking around in this code.

I dropped the name "Headers" from the two events, for symmetry the corresponding `-Received` event names.

I also tweaked `request_sent()` to use the new event, otherwise coverage gets antsy about the class we’ve defined but never used.