### PR TITLE
Correctly handle user-initiated changes of MAX_FRAME_SIZE.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -60,6 +60,10 @@ Bugfixes
   per RFC 7540 Section 8.1.2.4.
 - Correctly refuse to send responses that do not contain the ``:status`` header
   field, per RFC 7540 Section 8.1.2.4.
+- Correctly update the maximum frame size when the user updates the value of
+  that setting. Prior to this release, if the user updated the maximum frame
+  size hyper-h2 would ignore the update, preventing the remote peer from using
+  the higher frame sizes.
 
 
 2.4.0 (2016-07-01)

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -1795,6 +1795,10 @@ class H2Connection(object):
             setting = changes[MAX_HEADER_LIST_SIZE]
             self.decoder.max_header_list_size = setting.new_value
 
+        if MAX_FRAME_SIZE in changes:
+            setting = changes[MAX_FRAME_SIZE]
+            self.max_inbound_frame_size = setting.new_value
+
         return changes
 
     def _stream_id_is_outbound(self, stream_id):

--- a/test/test_basic_logic.py
+++ b/test/test_basic_logic.py
@@ -21,6 +21,9 @@ import h2.settings
 
 import helpers
 
+from hypothesis import given
+from hypothesis.strategies import integers
+
 
 IS_PYTHON3 = sys.version_info >= (3, 0)
 
@@ -688,6 +691,56 @@ class TestBasicClient(object):
         )
 
         assert c.data_to_send() == expected_frame.serialize()
+
+    @given(frame_size=integers(min_value=2**14, max_value=(2**24 - 1)))
+    def test_changing_max_frame_size(self, frame_factory, frame_size):
+        """
+        When the user changes the max frame size and the change is ACKed, the
+        remote peer is now bound by the new frame size.
+        """
+        # We need to refresh the encoder because hypothesis has a problem with
+        # integrating with py.test, meaning that we use the same frame factory
+        # for all tests.
+        # See https://github.com/HypothesisWorks/hypothesis-python/issues/377
+        frame_factory.refresh_encoder()
+
+        c = h2.connection.H2Connection()
+        c.initiate_connection()
+
+        # Set up the stream.
+        c.send_headers(1, self.example_request_headers, end_stream=True)
+        headers_frame = frame_factory.build_headers_frame(
+            headers=self.example_response_headers,
+        )
+        c.receive_data(headers_frame.serialize())
+
+        # Change the max frame size.
+        c.update_settings({h2.settings.MAX_FRAME_SIZE: frame_size})
+        settings_ack = frame_factory.build_settings_frame({}, ack=True)
+        c.receive_data(settings_ack.serialize())
+
+        # Greatly increase the flow control windows: we're not here to test
+        # flow control today.
+        c.increment_flow_control_window(increment=(2 * frame_size) + 1)
+        c.increment_flow_control_window(
+            increment=(2 * frame_size) + 1, stream_id=1
+        )
+
+        # Send one DATA frame that is exactly the max frame size: confirm it's
+        # fine.
+        data = frame_factory.build_data_frame(
+            data=(b'\x00' * frame_size),
+        )
+        events = c.receive_data(data.serialize())
+        assert len(events) == 1
+        assert isinstance(events[0], h2.events.DataReceived)
+        assert events[0].flow_controlled_length == frame_size
+
+        # Send one that is one byte too large: confirm a protocol error is
+        # raised.
+        data.data += b'\x00'
+        with pytest.raises(h2.exceptions.ProtocolError):
+            c.receive_data(data.serialize())
 
 
 class TestBasicServer(object):


### PR DESCRIPTION
Turns out that we wouldn't respect user-initiated increases to MAX_FRAME_SIZE. If the user increased MAX_FRAME_SIZE, and the remote peer then sent a frame in that was larger than the previous value of MAX_FRAME_SIZE, we'd call it a PROTOCOL_ERROR and terminate the connection. That's...that's not really ok.

This fixes that problem.