### PR TITLE
Add support for automated window management.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,8 @@ API Changes (Backward-Compatible)
 - Added a new ``H2Configuration`` object that allows rich configuration of
   a ``H2Connection``. This object supersedes the prior keyword arguments to the
   ``H2Connection`` object, which are now deprecated and will be removed in 3.0.
+- Added support for automated window management via the
+  ``acknowledge_received_data`` method. See the documentation for more details.
 - Added a ``DenialOfServiceError`` that is raised whenever a behaviour that
   looks like a DoS attempt is encountered: for example, an overly large
   decompressed header list. This is a subclass of ``ProtocolError``.

--- a/docs/source/advanced-usage.rst
+++ b/docs/source/advanced-usage.rst
@@ -294,3 +294,36 @@ stream ID of ``0``, that may have unblocked *all* streams that are currently
 blocked. The user should use :meth:`local_flow_control_window
 <h2.connection.H2Connection.local_flow_control_window>` to check all blocked
 streams to see if more data is available.
+
+Auto Flow Control
+~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 2.5.0
+
+In most cases, there is no advantage for users in managing their own flow
+control strategies. While particular high performance or specific-use-case
+applications may gain value from directly controlling the emission of
+``WINDOW_UPDATE`` frames, the average application can use a
+lowest-common-denominator strategy to emit those frames. As of version 2.5.0,
+hyper-h2 now provides this automatic strategy for users, if they want to use
+it.
+
+This automatic strategy is built around a single method:
+:meth:`acknowledge_received_data
+<h2.connection.H2Connection.acknowledge_received_data>`. This method
+flags to the connection object that your application has dealt with a certain
+number of flow controlled bytes, and that the window should be incremented in
+some way. Whenever your application has "processed" some received bytes, this
+method should be called to signal that they have been processed.
+
+The key difference between this method and :meth:`increment_flow_control_window
+<h2.connection.H2Connection.increment_flow_control_window>` is that the method
+:meth:`acknowledge_received_data
+<h2.connection.H2Connection.acknowledge_received_data>` does not guarantee that
+it will emit a ``WINDOW_UPDATE`` frame, and if it does it will not necessarily
+emit them for *only* the stream or *only* the frame. Instead, the
+``WINDOW_UPDATE`` frames will be *coalesced*: they will be emitted only when
+a certain number of bytes have been freed up.
+
+For most applications, this method should be preferred to the manual flow
+control mechanism.

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -17,6 +17,7 @@ Connection
 
 .. autoclass:: h2.connection.H2Connection
    :members:
+   :exclude-members: inbound_flow_control_window
 
 
 Configuration

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -915,17 +915,10 @@ class H2Connection(object):
             frames = stream.increase_flow_control_window(
                 increment
             )
-            stream.inbound_flow_control_window = guard_increment_window(
-                stream.inbound_flow_control_window,
-                increment
-            )
         else:
+            self._inbound_flow_control_window_manager.window_opened(increment)
             f = WindowUpdateFrame(0)
             f.window_increment = increment
-            self.inbound_flow_control_window = guard_increment_window(
-                self.inbound_flow_control_window,
-                increment
-            )
             frames = [f]
 
         self._prepare_for_sending(frames)

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -1284,9 +1284,10 @@ class H2Connection(object):
         :returns: Nothing
         :rtype: ``None``
         """
-        if not stream_id:
+        if stream_id <= 0:
             raise ValueError(
-                "Stream ID 0 is not valid for acknowledge_received_data"
+                "Stream ID %d is not valid for acknowledge_received_data" %
+                stream_id
             )
         if acknowledged_size < 0:
             raise ValueError("Cannot acknowledge negative data")

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -1303,7 +1303,7 @@ class H2Connection(object):
 
         try:
             stream = self._get_stream_by_id(stream_id)
-        except NoSuchStreamError:
+        except StreamClosedError:
             # The stream is already gone. We're not worried about incrementing
             # the window in this case.
             pass

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -1395,7 +1395,7 @@ class H2Connection(object):
         delta = new_value - old_value
 
         for stream in self.streams.values():
-            stream.inbound_flow_control_window += delta
+            stream._inbound_flow_control_change_from_settings(delta)
 
     def receive_data(self, data):
         """

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -1266,6 +1266,8 @@ class H2Connection(object):
         the space should be handed back to the remote peer at an opportune
         time.
 
+        .. versionadded:: 2.5.0
+
         :param acknowledged_size: The total *flow-controlled size* of the data
             that has been processed. Note that this must include the amount of
             padding that was sent with that data.

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -390,7 +390,7 @@ class H2Connection(object):
 
         # The flow control window manager for the connection.
         self._inbound_flow_control_window_manager = WindowManager(
-            max_window_size=self.outbound_flow_control_window
+            max_window_size=self.inbound_flow_control_window
         )
 
         # When in doubt use dict-dispatch.

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -1308,7 +1308,11 @@ class H2Connection(object):
             # the window in this case.
             pass
         else:
-            frames.extend(stream.acknowledge_received_data(acknowledged_size))
+            # No point incrementing the windows of closed streams.
+            if stream.open:
+                frames.extend(
+                    stream.acknowledge_received_data(acknowledged_size)
+                )
 
         self._prepare_for_sending(frames)
 

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -1259,7 +1259,7 @@ class H2Connection(object):
             stream.inbound_flow_control_window
         )
 
-    def acknowledge_received_data(self, acknowledged_size):
+    def acknowledge_received_data(self, acknowledged_size, stream_id):
         """
         Inform the :class:`H2Connection <h2.connection.H2Connection>` that a
         certain number of flow-controlled bytes have been processed, and that
@@ -1270,10 +1270,11 @@ class H2Connection(object):
             that has been processed. Note that this must include the amount of
             padding that was sent with that data.
         :type acknowledged_size: ``int``
+        :param stream_id: The ID of the stream on which this data was received.
+        :type stream_id: ``int``
         :returns: Nothing
         :rtype: ``None``
         """
-        pass
 
     def data_to_send(self, amt=None):
         """

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -879,7 +879,7 @@ class H2Connection(object):
            Rejects attempts to increment the flow control window by out of
            range values with a ``ValueError``.
 
-        :param increment: The amount ot increment the flow control window by.
+        :param increment: The amount to increment the flow control window by.
         :type increment: ``int``
         :param stream_id: (optional) The ID of the stream that should have its
             flow control window opened. If not present or ``None``, the

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -518,13 +518,14 @@ class H2Connection(object):
                 "Invalid stream ID for peer."
             )
 
-        s = H2Stream(stream_id, config=self.config)
+        s = H2Stream(
+            stream_id,
+            config=self.config,
+            inbound_window_size=self.local_settings.initial_window_size,
+            outbound_window_size-self.remote_settings.initial_window_size
+        )
         s.max_inbound_frame_size = self.max_inbound_frame_size
         s.max_outbound_frame_size = self.max_outbound_frame_size
-        s.outbound_flow_control_window = (
-            self.remote_settings.initial_window_size
-        )
-        s.inbound_flow_control_window = self.local_settings.initial_window_size
 
         self.streams[stream_id] = s
 

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -1275,6 +1275,14 @@ class H2Connection(object):
         :returns: Nothing
         :rtype: ``None``
         """
+        if not stream_id:
+            raise ValueError(
+                "Stream ID 0 is not valid for acknowledge_received_data"
+            )
+        if acknowledged_size < 0:
+            raise ValueError("Cannot acknowledge negative data")
+
+        return
 
     def data_to_send(self, amt=None):
         """

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -1259,6 +1259,22 @@ class H2Connection(object):
             stream.inbound_flow_control_window
         )
 
+    def acknowledge_received_data(self, acknowledged_size):
+        """
+        Inform the :class:`H2Connection <h2.connection.H2Connection>` that a
+        certain number of flow-controlled bytes have been processed, and that
+        the space should be handed back to the remote peer at an opportune
+        time.
+
+        :param acknowledged_size: The total *flow-controlled size* of the data
+            that has been processed. Note that this must include the amount of
+            padding that was sent with that data.
+        :type acknowledged_size: ``int``
+        :returns: Nothing
+        :rtype: ``None``
+        """
+        pass
+
     def data_to_send(self, amt=None):
         """
         Returns some data for sending out of the internal data buffer.

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -1600,28 +1600,6 @@ class H2Connection(object):
         """
         flow_controlled_length = frame.flow_controlled_length
 
-        try:
-            window_size = self.remote_flow_control_window(frame.stream_id)
-        except NoSuchStreamError:
-            # If the stream doesn't exist we still want to adjust the
-            # connection-level flow control window to keep parity with the
-            # remote peer. If it does exist we'll adjust it later.
-            self._inbound_flow_control_window_manager.window_consumed(
-                flow_controlled_length
-            )
-            raise
-
-        # TODO: Can we make this check happen in the window manager? I think we
-        # can!
-        if flow_controlled_length > window_size:
-            raise FlowControlError(
-                "Cannot receive %d bytes, flow control window is %d." %
-                (
-                    flow_controlled_length,
-                    window_size
-                )
-            )
-
         events = self.state_machine.process_input(
             ConnectionInputs.RECV_DATA
         )

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -522,7 +522,7 @@ class H2Connection(object):
             stream_id,
             config=self.config,
             inbound_window_size=self.local_settings.initial_window_size,
-            outbound_window_size-self.remote_settings.initial_window_size
+            outbound_window_size=self.remote_settings.initial_window_size
         )
         s.max_inbound_frame_size = self.max_inbound_frame_size
         s.max_outbound_frame_size = self.max_outbound_frame_size

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -1174,9 +1174,9 @@ class H2Stream(object):
         current window size, but we also need to set the target maximum window
         size to the new value.
         """
-        new_max_size = self._inbound_window_manager.max_size + delta
+        new_max_size = self._inbound_window_manager.max_window_size + delta
         self._inbound_window_manager.window_opened(delta)
-        self._inbound_window_manager.max_size = new_max_size
+        self._inbound_window_manager.max_window_size = new_max_size
 
 
 def _decode_headers(headers, encoding):

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -885,6 +885,8 @@ class H2Stream(object):
         Increase the size of the flow control window for the remote side.
         """
         self.state_machine.process_input(StreamInputs.SEND_WINDOW_UPDATE)
+        self._inbound_window_manager.window_opened(increment)
+
         wuf = WindowUpdateFrame(self.stream_id)
         wuf.window_increment = increment
         return [wuf]

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -1166,6 +1166,18 @@ class H2Stream(object):
             if end_stream and expected != actual:
                 raise InvalidBodyLengthError(expected, actual)
 
+    def _inbound_flow_control_change_from_settings(self, delta):
+        """
+        We changed SETTINGS_INITIAL_WINDOW_SIZE, which means we need to
+        update the target window size for flow control. For our flow control
+        strategy, this means we need to do two things: we need to adjust the
+        current window size, but we also need to set the target maximum window
+        size to the new value.
+        """
+        new_max_size = self._inbound_window_manager.max_size + delta
+        self._inbound_window_manager.window_opened(delta)
+        self._inbound_window_manager.max_size = new_max_size
+
 
 def _decode_headers(headers, encoding):
     """

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -1050,6 +1050,22 @@ class H2Stream(object):
 
         return [], events
 
+    def acknowledge_received_data(self, acknowledged_size):
+        """
+        The user has informed us that they've processed some amount of data
+        that was received on this stream. Pass that to the window manager and
+        potentially return some WindowUpdate frames.
+        """
+        increment = self._inbound_window_manager.process_bytes(
+            acknowledged_size
+        )
+        if increment:
+            f = WindowUpdateFrame(self.stream_id)
+            f.window_increment = increment
+            return [f]
+
+        return []
+
     def _build_hdr_validation_flags(self, events):
         """
         Constructs a set of header validation flags for use when normalizing

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -963,8 +963,6 @@ class H2Stream(object):
         Receive some data.
         """
         events = self.state_machine.process_input(StreamInputs.RECV_DATA)
-        # TODO: don't need this.
-        self.inbound_flow_control_window -= flow_control_len
         self._inbound_window_manager.window_consumed(flow_control_len)
         self._track_content_length(len(data), end_stream)
 

--- a/h2/windows.py
+++ b/h2/windows.py
@@ -14,7 +14,7 @@ does not emit too many WINDOW_UPDATE frames.
 """
 from __future__ import division
 
-import h2.exceptions
+from .exceptions import ProtocolError
 
 
 class WindowManager(object):
@@ -42,9 +42,7 @@ class WindowManager(object):
         """
         self.current_window_size -= size
         if self.current_window_size < 0:
-            raise h2.exceptions.ProtocolError(
-                "Flow control window shrunk below 0"
-            )
+            raise ProtocolError("Flow control window shrunk below 0")
 
     def process_bytes(self, size):
         """

--- a/h2/windows.py
+++ b/h2/windows.py
@@ -14,7 +14,7 @@ does not emit too many WINDOW_UPDATE frames.
 """
 from __future__ import division
 
-from .exceptions import ProtocolError, FlowControlError
+from .exceptions import FlowControlError
 
 
 # The largest acceptable value for a HTTP/2 flow control window.

--- a/h2/windows.py
+++ b/h2/windows.py
@@ -94,9 +94,11 @@ class WindowManager(object):
                 self._bytes_processed > min(1024, self.max_window_size // 4)):
             increment = self._bytes_processed
             self._bytes_processed = 0
+            self.current_window_size += increment
             return increment
 
         if self._bytes_processed >= (self.max_window_size // 2):
             increment = self._bytes_processed
             self._bytes_processed = 0
+            self.current_window_size += increment
             return increment

--- a/h2/windows.py
+++ b/h2/windows.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+"""
+h2/windows
+~~~~~~~~~~
+
+Defines tools for managing HTTP/2 flow control windows.
+
+The objects defined in this module are used to automatically manage HTTP/2
+flow control windows. Specifically, they keep track of what the size of the
+window is, how much data has been consumed from that window, and how much data
+the user has already used. It then implements a basic algorithm that attempts
+to manage the flow control window without user input, trying to ensure that it
+does not emit too many WINDOW_UPDATE frames.
+"""
+from __future__ import division
+
+import h2.exceptions
+
+
+class WindowManager(object):
+    """
+    A basic HTTP/2 window manager.
+
+    :param max_window_size: The maximum size of the flow control window.
+    :type max_window_size: ``int``
+    """
+    def __init__(self, max_window_size):
+        self.max_window_size = max_window_size
+        self.current_window_size = max_window_size
+        self._bytes_processed = 0
+
+    def window_consumed(self, size):
+        """
+        We have received a certain number of bytes from the remote peer. This
+        necessarily shrinks the flow control window!
+
+        :param size: The number of flow controlled bytes we received from the
+            remote peer.
+        :type size: ``int``
+        :returns: Nothing.
+        :rtype: ``None``
+        """
+        self.current_window_size -= size
+        if self.current_window_size < 0:
+            raise h2.exceptions.ProtocolError(
+                "Flow control window shrunk below 0"
+            )
+
+    def process_bytes(self, size):
+        """
+        The application has informed us that it has processed a certain number
+        of bytes. This may cause us to want to emit a window update frame. If
+        we do want to emit a window update frame, this method will return the
+        number of bytes that we should increment the window by.
+
+        :param size: The number of flow controlled bytes that the application
+            has processed.
+        :type size: ``int``
+        :returns: The number of bytes to increment the flow control window by,
+            or ``None``.
+        :rtype: ``int`` or ``None``
+        """
+        self._bytes_processed += size
+        return self._maybe_update_window()
+
+    def _maybe_update_window(self):
+        """
+        Run the algorithm.
+
+        Our current algorithm can be described like this.
+
+        1. If no bytes have been processed, we immediately return 0. There is
+           no meaningful way for us to hand space in the window back to the
+           remote peer, so let's not even try.
+        2. If there is no space in the flow control window, and we have
+           processed at least 1024 bytes (or 1/4 of the window, if the window
+           is smaller), we will emit a window update frame. This is to avoid
+           the risk of blocking a stream altogether.
+        3. If there is space in the flow control window, and we have processed
+           at least 1/2 of the window worth of bytes, we will emit a window
+           update frame. This is to minimise the number of window update frames
+           we have to emit.
+
+        In a healthy system with large flow control windows, this will
+        irregularly emit WINDOW_UPDATE frames. This prevents us starving the
+        connection by emitting eleventy bajillion WINDOW_UPDATE frames,
+        especially in situations where the remote peer is sending a lot of very
+        small DATA frames.
+        """
+        # TODO: Can the window be smaller than 1024 bytes? If not, we can
+        # streamline this algorithm.
+        if not self._bytes_processed:
+            return None
+
+        if (self.current_window_size == 0) and (
+                self._bytes_processed > min(1024, self.max_window_size // 4)):
+            increment = self._bytes_processed
+            self._bytes_processed = 0
+            return increment
+
+        if self._bytes_processed >= (self.max_window_size // 2):
+            increment = self._bytes_processed
+            self._bytes_processed = 0
+            return increment

--- a/h2/windows.py
+++ b/h2/windows.py
@@ -121,15 +121,19 @@ class WindowManager(object):
         if not self._bytes_processed:
             return None
 
+        max_increment = (self.max_window_size - self.current_window_size)
+        increment = 0
+
+        # Note that, even though we may increment less than _bytes_processed,
+        # we still want to set it to zero whenever we emit an increment. This
+        # is because we'll always increment up to the maximum we can.
         if (self.current_window_size == 0) and (
                 self._bytes_processed > min(1024, self.max_window_size // 4)):
-            increment = self._bytes_processed
+            increment = min(self._bytes_processed, max_increment)
             self._bytes_processed = 0
-            self.current_window_size += increment
-            return increment
+        elif self._bytes_processed >= (self.max_window_size // 2):
+            increment = min(self._bytes_processed, max_increment)
+            self._bytes_processed = 0
 
-        if self._bytes_processed >= (self.max_window_size // 2):
-            increment = self._bytes_processed
-            self._bytes_processed = 0
-            self.current_window_size += increment
-            return increment
+        self.current_window_size += increment
+        return increment

--- a/test/test_flow_control_window.py
+++ b/test/test_flow_control_window.py
@@ -743,6 +743,17 @@ class TestAutomaticFlowControl(object):
         )
         assert c.data_to_send() == expected.serialize()
 
+    def test_acknowledging_streams_we_never_saw(self, frame_factory):
+        """
+        If the user acknowledges a stream ID we've never seen, that raises a
+        NoSuchStreamError.
+        """
+        c = self._setup_connection_and_send_headers(frame_factory)
+        c.clear_outbound_data_buffer()
+
+        with pytest.raises(h2.exceptions.NoSuchStreamError):
+            c.acknowledge_received_data(2048, stream_id=101)
+
     @given(integers(min_value=1025, max_value=DEFAULT_FLOW_WINDOW))
     def test_acknowledging_1024_bytes_when_empty_increments(self,
                                                             frame_factory,

--- a/test/test_flow_control_window.py
+++ b/test/test_flow_control_window.py
@@ -698,7 +698,7 @@ class TestAutomaticFlowControl(object):
         )
         assert c.data_to_send() == expected_data
 
-    @given(integers(min_value=1025, max_value=DEFAULT_FLOW_WINDOW))
+    @given(integers(min_value=1025, max_value=(DEFAULT_FLOW_WINDOW // 4) - 1))
     def test_connection_only_empty(self, frame_factory, increment):
         """
         If the connection flow control window is empty, but the stream flow

--- a/test/test_flow_control_window.py
+++ b/test/test_flow_control_window.py
@@ -628,6 +628,7 @@ class TestAutomaticFlowControl(object):
         """
         c = h2.connection.H2Connection(client_side=False)
         c.initiate_connection()
+        c.receive_data(frame_factory.preamble())
         c.clear_outbound_data_buffer()
 
         headers_frame = frame_factory.build_headers_frame(

--- a/test/test_flow_control_window.py
+++ b/test/test_flow_control_window.py
@@ -688,10 +688,10 @@ class TestAutomaticFlowControl(object):
         c.acknowledge_received_data(increment, stream_id=1)
 
         first_expected = frame_factory.build_window_update_frame(
-            stream_id=1, increment=increment
+            stream_id=0, increment=increment
         )
         second_expected = frame_factory.build_window_update_frame(
-            stream_id=0, increment=increment
+            stream_id=1, increment=increment
         )
         expected_data = b''.join(
             [first_expected.serialize(), second_expected.serialize()]

--- a/test/test_flow_control_window.py
+++ b/test/test_flow_control_window.py
@@ -656,7 +656,7 @@ class TestAutomaticFlowControl(object):
         data_frame = frame_factory.build_data_frame(
             b'some data', flags=['END_STREAM']
         )
-        data_event = c.receive_data(data_frame.seriaize())[0]
+        data_event = c.receive_data(data_frame.serialize())[0]
 
         c.acknowledge_received_data(
             data_event.flow_controlled_length, stream_id=1

--- a/test/test_flow_control_window.py
+++ b/test/test_flow_control_window.py
@@ -698,6 +698,8 @@ class TestAutomaticFlowControl(object):
         )
         assert c.data_to_send() == expected_data
 
+    # This test needs to use a lower cap, because otherwise the algo will
+    # increment the stream window anyway.
     @given(integers(min_value=1025, max_value=(DEFAULT_FLOW_WINDOW // 4) - 1))
     def test_connection_only_empty(self, frame_factory, increment):
         """

--- a/test/test_flow_control_window.py
+++ b/test/test_flow_control_window.py
@@ -711,7 +711,10 @@ class TestAutomaticFlowControl(object):
 
         assert not c.data_to_send()
 
-    def test_acknowledging_data_on_closed_stream(self, frame_factory):
+    @pytest.mark.parametrize('force_cleanup', (True, False))
+    def test_acknowledging_data_on_closed_stream(self,
+                                                 frame_factory,
+                                                 force_cleanup):
         """
         When acknowledging data on a stream that has just been closed, no
         acknowledgement is given for that stream, only for the connection.
@@ -727,6 +730,11 @@ class TestAutomaticFlowControl(object):
         )
         c.receive_data(rst_frame.serialize())
         c.clear_outbound_data_buffer()
+
+        if force_cleanup:
+            # Check how many streams are open to force the old one to be
+            # cleaned up.
+            assert c.open_outbound_streams == 0
 
         c.acknowledge_received_data(2048, stream_id=1)
 

--- a/test/test_flow_control_window.py
+++ b/test/test_flow_control_window.py
@@ -673,6 +673,12 @@ class TestAutomaticFlowControl(object):
         more, we will emit a WINDOW_UPDATE frame just to move the connection
         forward.
         """
+        # We need to refresh the encoder because hypothesis has a problem with
+        # integrating with py.test, meaning that we use the same frame factory
+        # for all tests.
+        # See https://github.com/HypothesisWorks/hypothesis-python/issues/377
+        frame_factory.refresh_encoder()
+
         c = self._setup_connection_and_send_headers(frame_factory)
 
         data_to_send = b'\x00' * self.DEFAULT_FLOW_WINDOW
@@ -699,6 +705,12 @@ class TestAutomaticFlowControl(object):
         control windows aren't, and 1024 bytes or more are acknowledged by the
         user, we increment the connection window only.
         """
+        # We need to refresh the encoder because hypothesis has a problem with
+        # integrating with py.test, meaning that we use the same frame factory
+        # for all tests.
+        # See https://github.com/HypothesisWorks/hypothesis-python/issues/377
+        frame_factory.refresh_encoder()
+
         # Here we'll use 4 streams. Set them up.
         c = self._setup_connection_and_send_headers(frame_factory)
 
@@ -735,6 +747,12 @@ class TestAutomaticFlowControl(object):
         If the user mixes ackowledging data with manually incrementing windows,
         we still keep track of what's going on.
         """
+        # We need to refresh the encoder because hypothesis has a problem with
+        # integrating with py.test, meaning that we use the same frame factory
+        # for all tests.
+        # See https://github.com/HypothesisWorks/hypothesis-python/issues/377
+        frame_factory.refresh_encoder()
+
         # Empty the flow control window.
         c = self._setup_connection_and_send_headers(frame_factory)
         data_to_send = b'\x00' * self.DEFAULT_FLOW_WINDOW

--- a/test/test_flow_control_window.py
+++ b/test/test_flow_control_window.py
@@ -714,7 +714,7 @@ class TestAutomaticFlowControl(object):
         # Here we'll use 4 streams. Set them up.
         c = self._setup_connection_and_send_headers(frame_factory)
 
-        for stream_id in [2, 3, 4]:
+        for stream_id in [3, 5, 7]:
             f = frame_factory.build_headers_frame(
                 headers=self.example_request_headers, stream_id=stream_id
             )
@@ -723,14 +723,14 @@ class TestAutomaticFlowControl(object):
         # Now we send 1/4 of the connection window per stream. Annoyingly,
         # that's an odd number, so we need to round the last frame up.
         data_to_send = b'\x00' * (self.DEFAULT_FLOW_WINDOW // 4)
-        for stream_id in [1, 2, 3]:
+        for stream_id in [1, 3, 5]:
             f = frame_factory.build_data_frame(
                 data_to_send, stream_id=stream_id
             )
             c.receive_data(f.serialize())
 
-        data_to_send = b'\x00' * c.remote_flow_control_window(4)
-        data_frame = frame_factory.build_data_frame(data_to_send, stream_id=4)
+        data_to_send = b'\x00' * c.remote_flow_control_window(7)
+        data_frame = frame_factory.build_data_frame(data_to_send, stream_id=7)
         c.receive_data(data_frame.serialize())
 
         # Ok, now the actual test.

--- a/test/test_flow_control_window.py
+++ b/test/test_flow_control_window.py
@@ -664,7 +664,7 @@ class TestAutomaticFlowControl(object):
 
         assert not c.data_to_send()
 
-    @given(integers(min_value=1024, max_value=DEFAULT_FLOW_WINDOW))
+    @given(integers(min_value=1025, max_value=DEFAULT_FLOW_WINDOW))
     def test_acknowledging_1024_bytes_when_empty_increments(self,
                                                             frame_factory,
                                                             increment):
@@ -698,7 +698,7 @@ class TestAutomaticFlowControl(object):
         )
         assert c.data_to_send() == expected_data
 
-    @given(integers(min_value=1024, max_value=DEFAULT_FLOW_WINDOW))
+    @given(integers(min_value=1025, max_value=DEFAULT_FLOW_WINDOW))
     def test_connection_only_empty(self, frame_factory, increment):
         """
         If the connection flow control window is empty, but the stream flow
@@ -741,7 +741,7 @@ class TestAutomaticFlowControl(object):
         ).serialize()
         assert c.data_to_send() == expected_data
 
-    @given(integers(min_value=1024, max_value=DEFAULT_FLOW_WINDOW))
+    @given(integers(min_value=1025, max_value=DEFAULT_FLOW_WINDOW))
     def test_mixing_update_forms(self, frame_factory, increment):
         """
         If the user mixes ackowledging data with manually incrementing windows,

--- a/test/test_flow_control_window.py
+++ b/test/test_flow_control_window.py
@@ -624,11 +624,19 @@ class TestAutomaticFlowControl(object):
     def _setup_connection_and_send_headers(self, frame_factory):
         """
         Setup a server-side H2Connection and send a headers frame, and then
-        clear the outbound data buffer.
+        clear the outbound data buffer. Also increase the maximum frame size.
         """
         c = h2.connection.H2Connection(client_side=False)
         c.initiate_connection()
         c.receive_data(frame_factory.preamble())
+
+        c.update_settings(
+            {h2.settings.MAX_FRAME_SIZE: self.DEFAULT_FLOW_WINDOW}
+        )
+        settings_frame = frame_factory.build_settings_frame(
+            settings={}, ack=True
+        )
+        c.receive_data(settings_frame.serialize())
         c.clear_outbound_data_buffer()
 
         headers_frame = frame_factory.build_headers_frame(

--- a/test/test_flow_control_window.py
+++ b/test/test_flow_control_window.py
@@ -711,6 +711,20 @@ class TestAutomaticFlowControl(object):
 
         assert not c.data_to_send()
 
+    def test_acknowledging_no_data_does_nothing(self, frame_factory):
+        """
+        If a user accidentally acknowledges no data, nothing happens.
+        """
+        c = self._setup_connection_and_send_headers(frame_factory)
+
+        # Send an empty data frame, just to give the user impetus to ack the
+        # data.
+        data_frame = frame_factory.build_data_frame(b'')
+        c.receive_data(data_frame.serialize())
+
+        c.acknowledge_received_data(0, stream_id=1)
+        assert not c.data_to_send()
+
     @pytest.mark.parametrize('force_cleanup', (True, False))
     def test_acknowledging_data_on_closed_stream(self,
                                                  frame_factory,

--- a/test/test_flow_control_window.py
+++ b/test/test_flow_control_window.py
@@ -766,6 +766,7 @@ class TestAutomaticFlowControl(object):
         c.increment_flow_control_window(
             stream_id=None, increment=self.DEFAULT_FLOW_WINDOW
         )
+        c.clear_outbound_data_buffer()
 
         # Now, acknowledge the receipt of that data. This should cause the
         # stream window to be widened, but not the connection window, because


### PR DESCRIPTION
Resolves #272.

This PR would add functionality for allowing hyper-h2 to make window management decisions for users. Rather than before, when users had to choose when to increment flow control windows and by how much, this change would allow users to simply inform hyper-h2 when they are done with data that has been received, and hyper-h2 will choose when to actually increment the flow control window.

This helps users who are implementing naive flow control algorithms, which may cause a barrage of WINDOW_UPDATE frames to be emitted, clogging up the network for no good reason.

Unfortunately, this turned into a fairly sizeable change. It adds quite a complex and subtle bit of function.