### PR TITLE
Disable slow health checks on Travis.

### DIFF
--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -4,8 +4,8 @@ set -e
 set -x
 
 if [[ $TRAVIS_PYTHON_VERSION == pypy ]]; then
-    py.test test/
+    py.test --hypothesis-profile travis test/
 else
-    coverage run -m py.test test/
+    coverage run -m py.test --hypothesis-profile travis test/
     coverage report
 fi

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,14 @@
 # -*- coding: utf-8 -*-
+from hypothesis import settings, HealthCheck
+
 import pytest
 import helpers
+
+# Set up a CI profile that allows slow example generation.
+settings.register_profile(
+    "travis",
+    settings(suppress_health_check=[HealthCheck.too_slow])
+)
 
 
 @pytest.fixture


### PR DESCRIPTION
Resolves #362. Increasingly important as we rely more on Hypothesis in our testing.