### PR TITLE
Run the tests the way Twisted wants them run.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
     idna
     priority
     sphinx
-commands = trial --reporter=text twisted
+commands = python -m twisted.trial --reporter=text twisted
 
 [testenv:lint]
 basepython=python3.4


### PR DESCRIPTION
Looks like one of Twisted's tests fails if run directly via `trial`.

I actually think this is a Twisted bug, but for the moment let's work around it here. I'll follow up with Twisted directly.