### PR TITLE
Backport fix for Twisted test runs from master branch.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
     idna
     priority
     sphinx
-commands = trial --reporter=text twisted
+commands = python -m twisted.trial --reporter=text twisted
 
 [testenv:lint]
 basepython=python3.4


### PR DESCRIPTION
Backport of #372 to 2.5.X branch.