### PR TITLE
Validate push promise header fields.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,14 @@ API Changes (Backward-Compatible)
 - Added a new ``h2.events.Event`` class that acts as a base class for all
   events.
 
+Bugfixes
+~~~~~~~~
+
+- Correctly reject pushed request header blocks whenever they have malformed
+  request header blocks.
+- Correctly normalize pushed request header blocks whenever they have
+  normalizable header fields.
+
 2.5.0 (2016-10-25)
 ------------------
 

--- a/h2/events.py
+++ b/h2/events.py
@@ -188,6 +188,17 @@ class _TrailersSent(_HeadersSent):
     pass
 
 
+class _PushedRequestSent(_HeadersSent):
+    """
+    The _PushedRequestSent event is fired whenever pushed request headers are
+    sent.
+
+    This is an internal event, used to determine validation steps on outgoing
+    header blocks.
+    """
+    pass
+
+
 class InformationalResponseReceived(Event):
     """
     The InformationalResponseReceived event is fired when an informational

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -1076,7 +1076,12 @@ class H2Stream(object):
                 events[0], (_TrailersSent, TrailersReceived)
             )
             is_response_header = isinstance(
-                events[0], (_ResponseSent, ResponseReceived)
+                events[0],
+                (
+                    _ResponseSent,
+                    ResponseReceived,
+                    InformationalResponseReceived
+                )
             )
         except IndexError:
             # Some state changes don't emit an internal event (for example,

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -1074,34 +1074,20 @@ class H2Stream(object):
         Constructs a set of header validation flags for use when normalizing
         and validating header blocks.
         """
-        try:
-            is_trailer = isinstance(
-                events[0], (_TrailersSent, TrailersReceived)
+        is_trailer = isinstance(
+            events[0], (_TrailersSent, TrailersReceived)
+        )
+        is_response_header = isinstance(
+            events[0],
+            (
+                _ResponseSent,
+                ResponseReceived,
+                InformationalResponseReceived
             )
-            is_response_header = isinstance(
-                events[0],
-                (
-                    _ResponseSent,
-                    ResponseReceived,
-                    InformationalResponseReceived
-                )
-            )
-            is_push_promise = isinstance(
-                events[0], (PushedStreamReceived)
-            )
-        except IndexError:
-            # Some state changes don't emit an internal event (for example,
-            # sending a push promise).  We *always* emit an event for trailers,
-            # so the absence of an event means this definitely isn't a trailer.
-            # Similarly, we also emit an event whenever response headers are
-            # sent or received. So absence of those events means this is not an
-            # response header either.
-            #
-            # TODO: Find any places where we don't emit anything, and emit
-            # an internal event, so we can do away with this branch.
-            is_trailer = False
-            is_response_header = False
-            is_push_promise = True
+        )
+        is_push_promise = isinstance(
+            events[0], (PushedStreamReceived, _PushedRequestSent)
+        )
 
         return HeaderValidationFlags(
             is_client=self.state_machine.client,

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -1083,6 +1083,9 @@ class H2Stream(object):
                     InformationalResponseReceived
                 )
             )
+            is_push_promise = isinstance(
+                events[0], (PushedStreamReceived)
+            )
         except IndexError:
             # Some state changes don't emit an internal event (for example,
             # sending a push promise).  We *always* emit an event for trailers,
@@ -1095,11 +1098,13 @@ class H2Stream(object):
             # an internal event, so we can do away with this branch.
             is_trailer = False
             is_response_header = False
+            is_push_promise = True
 
         return HeaderValidationFlags(
             is_client=self.state_machine.client,
             is_trailer=is_trailer,
-            is_response_header=is_response_header
+            is_response_header=is_response_header,
+            is_push_promise=is_push_promise,
         )
 
     def _build_headers_frames(self,

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -496,7 +496,7 @@ _transitions = {
 
     # State: reserved local
     (StreamState.RESERVED_LOCAL, StreamInputs.SEND_HEADERS):
-        (None, StreamState.HALF_CLOSED_REMOTE),
+        (H2StreamStateMachine.response_sent, StreamState.HALF_CLOSED_REMOTE),
     (StreamState.RESERVED_LOCAL, StreamInputs.RECV_DATA):
         (H2StreamStateMachine.send_reset, StreamState.CLOSED),
     (StreamState.RESERVED_LOCAL, StreamInputs.SEND_WINDOW_UPDATE):

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -905,6 +905,10 @@ class H2Stream(object):
         )
         events[0].pushed_stream_id = promised_stream_id
 
+        if self.config.validate_inbound_headers:
+            hdr_validation_flags = self._build_hdr_validation_flags(events)
+            headers = validate_headers(headers, hdr_validation_flags)
+
         if header_encoding:
             headers = list(_decode_headers(headers, header_encoding))
         events[0].headers = headers

--- a/h2/utilities.py
+++ b/h2/utilities.py
@@ -171,7 +171,7 @@ def authority_from_headers(headers):
 # should be applied to a given set of headers.
 HeaderValidationFlags = collections.namedtuple(
     'HeaderValidationFlags',
-    ['is_client', 'is_trailer', 'is_response_header']
+    ['is_client', 'is_trailer', 'is_response_header', 'is_push_promise']
 )
 
 

--- a/h2/utilities.py
+++ b/h2/utilities.py
@@ -402,9 +402,13 @@ def _check_host_authority_header(headers, hdr_validation_flags):
     but their values do not match.
     """
     # We only expect to see :authority and Host headers on request header
-    # blocks that aren't trailers, so skip this validation if we're on the
-    # server side or looking at trailer blocks.
-    if hdr_validation_flags.is_client or hdr_validation_flags.is_trailer:
+    # blocks that aren't trailers, so skip this validation if this is a
+    # response header or we're looking at trailer blocks.
+    skip_validation = (
+        hdr_validation_flags.is_response_header or
+        hdr_validation_flags.is_trailer
+    )
+    if skip_validation:
         return headers
 
     return _validate_host_authority_header(headers)
@@ -444,9 +448,13 @@ def _check_sent_host_authority_header(headers, hdr_validation_flags):
     the header block contains both fields, but their values do not match.
     """
     # We only expect to see :authority and Host headers on request header
-    # blocks that aren't trailers, so skip this validation if we're on the
-    # server side or looking at trailer blocks.
-    if not hdr_validation_flags.is_client or hdr_validation_flags.is_trailer:
+    # blocks that aren't trailers, so skip this validation if this is a
+    # response header or we're looking at trailer blocks.
+    skip_validation = (
+        hdr_validation_flags.is_response_header or
+        hdr_validation_flags.is_trailer
+    )
+    if skip_validation:
         return headers
 
     return _validate_host_authority_header(headers)

--- a/test/test_invalid_headers.py
+++ b/test/test_invalid_headers.py
@@ -382,10 +382,10 @@ class TestFilter(object):
 
     hdr_validation_combos = [
         h2.utilities.HeaderValidationFlags(
-            is_client, is_trailer, is_response_header
+            is_client, is_trailer, is_response_header, is_push_promise
         )
-        for is_client, is_trailer, is_response_header in (
-            itertools.product([True, False], repeat=3)
+        for is_client, is_trailer, is_response_header, is_push_promise in (
+            itertools.product([True, False], repeat=4)
         )
     ]
 


### PR DESCRIPTION
Resolves #318.

This seems to have been a smooth enough patch, which is a good thing! Suggests that our validation pipeline is pretty functional.