### PR TITLE
Remove connection specific headers

### DIFF
--- a/h2/utilities.py
+++ b/h2/utilities.py
@@ -441,6 +441,15 @@ def _strip_surrounding_whitespace(headers, hdr_validation_flags):
             yield (header[0].strip(), header[1].strip())
 
 
+def _strip_connection_headers(headers, hdr_validation_flags):
+    """
+    Strip any connection headers as per RFC7540 § 8.1.2.2.
+    """
+    for header in headers:
+        if header[0] not in CONNECTION_HEADERS:
+            yield header
+
+
 def _check_sent_host_authority_header(headers, hdr_validation_flags):
     """
     Raises an InvalidHeaderBlockError if we try to send a header block
@@ -469,6 +478,7 @@ def normalize_outbound_headers(headers, hdr_validation_flags):
     """
     headers = _lowercase_header_names(headers, hdr_validation_flags)
     headers = _strip_surrounding_whitespace(headers, hdr_validation_flags)
+    headers = _strip_connection_headers(headers, hdr_validation_flags)
     headers = _secure_headers(headers, hdr_validation_flags)
 
     return headers


### PR DESCRIPTION
This should address the issue discussed in lukasa/hyper#291. I expanded the scope of this PR a bit after reading RFC7540 because it has pretty clear wording on what to do in this situation.

###### RFC7540 §  8.1.2.2
> This means that an intermediary transforming an HTTP/1.x message to
   HTTP/2 will need to remove any header fields nominated by the
   Connection header field, along with the Connection header field
   itself.  Such intermediaries SHOULD also remove other connection-
   specific header fields, such as Keep-Alive, Proxy-Connection,
   Transfer-Encoding, and Upgrade, even if they are not nominated by the
   Connection header field.

There may have been another discussion on why this portion wasn't previously implemented but I couldn't find it from a cursory search.

With this patch, `h2` will now strip all connection related fields from headers. While the RFC specifies this specifically for messages transformed from HTTP/1.x to HTTP/2, I didn't initially implement a check because I wanted to check first. Does this distinction matter in practice, or will a universal strip work?