### PR TITLE
obtain stream_id from event object

### DIFF
--- a/examples/asyncio/wsgi-server.py
+++ b/examples/asyncio/wsgi-server.py
@@ -181,7 +181,7 @@ class H2Protocol(asyncio.Protocol):
             # This is specific to a single stream.
             if event.stream_id in self._flow_controlled_data:
                 self._stream_data.put_nowait(
-                    self._flow_controlled_data.pop(stream_id)
+                    self._flow_controlled_data.pop(event.stream_id)
                 )
         else:
             # This event is specific to the connection. Free up *all* the


### PR DESCRIPTION
While looking through the example code to understand how I can use h2 with asyncio I think I came across a minor bug. It looks like ``stream_id`` was used when really ``event.stream_id`` should be used.