### PR TITLE
Only include SettingsFrame payload in upgrade request for h2c

### DIFF
--- a/h2/connection.py
+++ b/h2/connection.py
@@ -593,7 +593,7 @@ class H2Connection(object):
             for setting, value in self.local_settings.items():
                 f.settings[setting] = value
 
-            frame_data = f.serialize()
+            frame_data = f.serialize_body()
             frame_data = base64.urlsafe_b64encode(frame_data)
 
         # Set up appropriate state. Stream 1 in a half-closed state:

--- a/test/test_h2_upgrade.py
+++ b/test/test_h2_upgrade.py
@@ -48,7 +48,7 @@ class TestClientUpgrade(object):
         expected_frame = frame_factory.build_settings_frame(
             settings=conn.local_settings
         )
-        assert decoded_frame == expected_frame.serialize()
+        assert decoded_frame == expected_frame.serialize_body()
 
     def test_emits_preamble(self, frame_factory):
         """


### PR DESCRIPTION
Resolved: #449 

Only update the code for client side.
The server side seems didn't parse the HTTP2-Settings value at the latest master version.