### PR TITLE
Minor typo fixes

### DIFF
--- a/docs/source/negotiating-http2.rst
+++ b/docs/source/negotiating-http2.rst
@@ -90,7 +90,7 @@ The code below demonstrates how to handle a plaintext upgrade from the perspecti
 Prior Knowledge
 ---------------
 
-It's possible that you as a client know that a particular server supports HTTP/2, and that you do not need to perform any of the negotiations decribed above. In that case, you may follow the steps in :ref:`starting-alpn`, ignoring all references to ALPN and NPN: there's no need to perform the upgrade dance described in :ref:`starting-upgrade`.
+It's possible that you as a client know that a particular server supports HTTP/2, and that you do not need to perform any of the negotiations described above. In that case, you may follow the steps in :ref:`starting-alpn`, ignoring all references to ALPN and NPN: there's no need to perform the upgrade dance described in :ref:`starting-upgrade`.
 
 .. _RFC 7540: https://tools.ietf.org/html/rfc7540
 .. _RFC 7540 Section 3.2: https://tools.ietf.org/html/rfc7540#section-3.2

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -20,7 +20,7 @@ ever to use Hyper-h2 to build a compliant HTTP/2 server or client.
 An enormous chunk of this work has been focused on tighter enforcement of
 restrictions in RFC 7540, ensuring that we correctly police the actions of
 remote peers, and error appropriately when those peers violate the
-specification. Several of these constitute breaking changes, becuase data that
+specification. Several of these constitute breaking changes, because data that
 was previously received and handled without obvious error now raises
 ``ProtocolError`` exceptions and causes the connection to be terminated.
 
@@ -42,7 +42,7 @@ were an attempt to make a forward-looking guarantee that was entirely unneeded.
 
 Altogether, this has been an extremely productive period for Hyper-h2, and a
 lot of great work has been done by the community. To that end, we'd also like
-to extend a great thankyou to those contributers who made their first contribution
+to extend a great thankyou to those contributors who made their first contribution
 to the project between release 1.0.0 and 2.0.0. Many thanks to:
 `Thomas Kriechbaumer`_, `Alex Chan`_, `Maximilian Hils`_, and `Glyph`_. For a
 full historical list of contributors, see :doc:`contributors`.

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -1330,7 +1330,7 @@ class H2Connection(object):
         """
         Returns some data for sending out of the internal data buffer.
 
-        This method is analagous to ``read`` on a file-like object, but it
+        This method is analogous to ``read`` on a file-like object, but it
         doesn't block. Instead, it returns as much data as the user asks for,
         or less if that much data is not available. It does not perform any
         I/O, and so uses a different name.

--- a/test/test_invalid_headers.py
+++ b/test/test_invalid_headers.py
@@ -487,7 +487,7 @@ class TestFilter(object):
 class TestOversizedHeaders(object):
     """
     Tests that oversized header blocks are correctly rejected. This replicates
-    the "HPACK Bomb" attack, and confirms that we're resistent against it.
+    the "HPACK Bomb" attack, and confirms that we're resistant against it.
     """
     request_header_block = [
         (b':method', b'GET'),


### PR DESCRIPTION
No functional changes to the codebase.

Automatically corrected with [codespell](https://github.com/lucasdemarchi/codespell).

Signed-off-by: Sam Bristow <sam.bristow@gmail.com>