### PR TITLE
Update asyncio-server example to let it could be test with h2spec

### DIFF
--- a/examples/asyncio/asyncio-server.py
+++ b/examples/asyncio/asyncio-server.py
@@ -21,8 +21,11 @@ import collections
 from typing import List, Tuple
 
 from h2.connection import H2Connection
-from h2.events import DataReceived, RequestReceived, StreamEnded
+from h2.events import (
+    ConnectionTerminated, DataReceived, RequestReceived, StreamEnded
+)
 from h2.errors import ErrorCodes
+from h2.exceptions import ProtocolError
 
 
 RequestData = collections.namedtuple('RequestData', ['headers', 'data'])
@@ -40,18 +43,24 @@ class H2Protocol(asyncio.Protocol):
         self.transport.write(self.conn.data_to_send())
 
     def data_received(self, data: bytes):
-        events = self.conn.receive_data(data)
-        self.transport.write(self.conn.data_to_send())
-
-        for event in events:
-            if isinstance(event, RequestReceived):
-                self.request_received(event.headers, event.stream_id)
-            elif isinstance(event, DataReceived):
-                self.receive_data(event.data, event.stream_id)
-            elif isinstance(event, StreamEnded):
-                self.stream_complete(event.stream_id)
-
+        try:
+            events = self.conn.receive_data(data)
+        except ProtocolError as e:
             self.transport.write(self.conn.data_to_send())
+            self.transport.close()
+        else:
+            self.transport.write(self.conn.data_to_send())
+            for event in events:
+                if isinstance(event, RequestReceived):
+                    self.request_received(event.headers, event.stream_id)
+                elif isinstance(event, DataReceived):
+                    self.receive_data(event.data, event.stream_id)
+                elif isinstance(event, StreamEnded):
+                    self.stream_complete(event.stream_id)
+                elif isinstance(event, ConnectionTerminated):
+                    self.transport.close()
+
+                self.transport.write(self.conn.data_to_send())
 
     def request_received(self, headers: List[Tuple[str, str]], stream_id: int):
         headers = collections.OrderedDict(headers)
@@ -86,7 +95,7 @@ class H2Protocol(asyncio.Protocol):
         response_headers = (
             (':status', '200'),
             ('content-type', 'application/json'),
-            ('content-length', len(data)),
+            ('content-length', str(len(data))),
             ('server', 'asyncio-h2'),
         )
         self.conn.send_headers(stream_id, response_headers)
@@ -116,7 +125,6 @@ class H2Protocol(asyncio.Protocol):
             )
         else:
             stream_data.data.write(data)
-
 
 
 ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)


### PR DESCRIPTION
I had updated ```examples/asyncio/asyncio-server.py```
To let it handle ProtocolError and ConnectionTerminated event,
so that it could be test with [h2spec](https://github.com/summerwind/h2spec).

Currently the execution result of h2spec is
```145 tests, 121 passed, 0 skipped, 24 failed```