### PR TITLE
Allow sending data frames with padding

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -22,6 +22,9 @@ API Changes (Backward-Compatible)
   a subclass of ``int``, this is non-breaking.
 - Deprecated the other fields in ``h2.settings``. These will be removed in
   3.0.0.
+- Added an optional ``pad_length`` parameter to ``H2Connection.send_data``
+  to allow the user to include padding on a data frame.
+
 
 Bugfixes
 ~~~~~~~~

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -833,7 +833,7 @@ class H2Connection(object):
 
         self._prepare_for_sending(frames)
 
-    def send_data(self, stream_id, data, end_stream=False):
+    def send_data(self, stream_id, data, end_stream=False, pad_length=None):
         """
         Send data on a given stream.
 
@@ -857,24 +857,44 @@ class H2Connection(object):
         :param end_stream: (optional) Whether this is the last data to be sent
             on the stream. Defaults to ``False``.
         :type end_stream: ``bool``
+        :param pad_length: (optional) Length of the padding to apply to the
+            data frame. Defaults to ``None`` for no use of padding. Note that
+            a value of ``0`` results in padding of length ``0``
+            (with the "padding" flag set on the frame).
+
+            .. versionadded:: 2.6.0
+
+        :type pad_length: ``int``
         :returns: Nothing
         """
-        if len(data) > self.local_flow_control_window(stream_id):
+        frame_size = len(data)
+        if pad_length is not None:
+            if not isinstance(pad_length, int):
+                raise TypeError("pad_length must be an int")
+            if pad_length < 0 or pad_length > 255:
+                raise ValueError("pad_length must be within range: [0, 255]")
+            # Account for padding bytes plus the 1-byte padding length field.
+            frame_size += pad_length + 1
+
+        if frame_size > self.local_flow_control_window(stream_id):
             raise FlowControlError(
                 "Cannot send %d bytes, flow control window is %d." %
-                (len(data), self.local_flow_control_window(stream_id))
+                (frame_size, self.local_flow_control_window(stream_id))
             )
-        elif len(data) > self.max_outbound_frame_size:
+        elif frame_size > self.max_outbound_frame_size:
             raise FrameTooLargeError(
                 "Cannot send frame size %d, max frame size is %d" %
-                (len(data), self.max_outbound_frame_size)
+                (frame_size, self.max_outbound_frame_size)
             )
 
         self.state_machine.process_input(ConnectionInputs.SEND_DATA)
-        frames = self.streams[stream_id].send_data(data, end_stream)
+        frames = self.streams[stream_id].send_data(
+            data, end_stream, pad_length=pad_length
+        )
+
         self._prepare_for_sending(frames)
 
-        self.outbound_flow_control_window -= len(data)
+        self.outbound_flow_control_window -= frame_size
         assert self.outbound_flow_control_window >= 0
 
     def end_stream(self, stream_id):

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -841,7 +841,7 @@ class H2Stream(object):
         assert not events
         return []
 
-    def send_data(self, data, end_stream=False):
+    def send_data(self, data, end_stream=False, pad_length=None):
         """
         Prepare some data frames. Optionally end the stream.
 
@@ -854,8 +854,12 @@ class H2Stream(object):
         if end_stream:
             self.state_machine.process_input(StreamInputs.SEND_END_STREAM)
             df.flags.add('END_STREAM')
+        if pad_length is not None:
+            df.flags.add('PADDED')
+            df.pad_length = pad_length
 
-        self.outbound_flow_control_window -= len(data)
+        # Subtract flow_controlled_length to account for possible padding
+        self.outbound_flow_control_window -= df.flow_controlled_length
         assert self.outbound_flow_control_window >= 0
 
         return [df]


### PR DESCRIPTION
This allows sending padding along with a data frame.

This defaults `pad_length` to `None`, indicating that padding flag should be unset - wanted to allow setting zero length padding with a zero-valued `pad_length`.