### PR TITLE
Update H2Configuration test to use init params

### DIFF
--- a/test/test_config.py
+++ b/test/test_config.py
@@ -36,8 +36,10 @@ class TestH2Config(object):
         The boolean config options raise an error if you try to set a value
         that isn't a boolean.
         """
-        config = h2.config.H2Configuration()
+        with pytest.raises(ValueError):
+            config = h2.config.H2Configuration(**{option_name: value})
 
+        config = h2.config.H2Configuration()
         with pytest.raises(ValueError):
             setattr(config, option_name, value)
 
@@ -52,6 +54,9 @@ class TestH2Config(object):
         setattr(config, option_name, value)
         assert getattr(config, option_name) == value
 
+        config = h2.config.H2Configuration(**{option_name: value})
+        assert getattr(config, option_name) == value
+
     @pytest.mark.parametrize('header_encoding', [True, 1, object()])
     def test_header_encoding_must_be_false_str_none(self, header_encoding):
         """
@@ -63,6 +68,9 @@ class TestH2Config(object):
         with pytest.raises(ValueError):
             config.header_encoding = header_encoding
 
+        with pytest.raises(ValueError):
+            config = h2.config.H2Configuration(header_encoding=header_encoding)
+
     @pytest.mark.parametrize('header_encoding', [False, 'ascii', None])
     def test_header_encoding_is_reflected(self, header_encoding):
         """
@@ -70,4 +78,7 @@ class TestH2Config(object):
         """
         config = h2.config.H2Configuration()
         config.header_encoding = header_encoding
+        assert config.header_encoding == header_encoding
+
+        config = h2.config.H2Configuration(header_encoding=header_encoding)
         assert config.header_encoding == header_encoding

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -31,54 +31,88 @@ class TestH2Config(object):
 
     @pytest.mark.parametrize('option_name', boolean_config_options)
     @pytest.mark.parametrize('value', [None, 'False', 1])
-    def test_boolean_config_options_reject_non_bools(self, option_name, value):
+    def test_boolean_config_options_reject_non_bools_init(
+        self, option_name, value
+    ):
         """
         The boolean config options raise an error if you try to set a value
-        that isn't a boolean.
+        that isn't a boolean via the initializer.
         """
         with pytest.raises(ValueError):
-            config = h2.config.H2Configuration(**{option_name: value})
+            h2.config.H2Configuration(**{option_name: value})
 
+    @pytest.mark.parametrize('option_name', boolean_config_options)
+    @pytest.mark.parametrize('value', [None, 'False', 1])
+    def test_boolean_config_options_reject_non_bools_attr(
+        self, option_name, value
+    ):
+        """
+        The boolean config options raise an error if you try to set a value
+        that isn't a boolean via attribute setter.
+        """
         config = h2.config.H2Configuration()
         with pytest.raises(ValueError):
             setattr(config, option_name, value)
 
     @pytest.mark.parametrize('option_name', boolean_config_options)
     @pytest.mark.parametrize('value', [True, False])
-    def test_boolean_config_option_is_reflected(self, option_name, value):
+    def test_boolean_config_option_is_reflected_init(self, option_name, value):
         """
         The value of the boolean config options, when set, is reflected
-        in the value.
+        in the value via the initializer.
+        """
+        config = h2.config.H2Configuration(**{option_name: value})
+        assert getattr(config, option_name) == value
+
+    @pytest.mark.parametrize('option_name', boolean_config_options)
+    @pytest.mark.parametrize('value', [True, False])
+    def test_boolean_config_option_is_reflected_attr(self, option_name, value):
+        """
+        The value of the boolean config options, when set, is reflected
+        in the value via attribute setter.
         """
         config = h2.config.H2Configuration()
         setattr(config, option_name, value)
         assert getattr(config, option_name) == value
 
-        config = h2.config.H2Configuration(**{option_name: value})
-        assert getattr(config, option_name) == value
-
     @pytest.mark.parametrize('header_encoding', [True, 1, object()])
-    def test_header_encoding_must_be_false_str_none(self, header_encoding):
+    def test_header_encoding_must_be_false_str_none_init(
+        self, header_encoding
+    ):
         """
         The value of the ``header_encoding`` setting must be False, a string,
-        or None.
+        or None via the initializer.
+        """
+        with pytest.raises(ValueError):
+            h2.config.H2Configuration(header_encoding=header_encoding)
+
+    @pytest.mark.parametrize('header_encoding', [True, 1, object()])
+    def test_header_encoding_must_be_false_str_none_attr(
+        self, header_encoding
+    ):
+        """
+        The value of the ``header_encoding`` setting must be False, a string,
+        or None via attribute setter.
         """
         config = h2.config.H2Configuration()
-
         with pytest.raises(ValueError):
             config.header_encoding = header_encoding
 
-        with pytest.raises(ValueError):
-            config = h2.config.H2Configuration(header_encoding=header_encoding)
+    @pytest.mark.parametrize('header_encoding', [False, 'ascii', None])
+    def test_header_encoding_is_reflected_init(self, header_encoding):
+        """
+        The value of ``header_encoding``, when set, is reflected in the value
+        via the initializer.
+        """
+        config = h2.config.H2Configuration(header_encoding=header_encoding)
+        assert config.header_encoding == header_encoding
 
     @pytest.mark.parametrize('header_encoding', [False, 'ascii', None])
-    def test_header_encoding_is_reflected(self, header_encoding):
+    def test_header_encoding_is_reflected_attr(self, header_encoding):
         """
-        The value of ``header_encoding``, when set, is reflected in the value.
+        The value of ``header_encoding``, when set, is reflected in the value
+        via the attribute setter.
         """
         config = h2.config.H2Configuration()
         config.header_encoding = header_encoding
-        assert config.header_encoding == header_encoding
-
-        config = h2.config.H2Configuration(header_encoding=header_encoding)
         assert config.header_encoding == header_encoding


### PR DESCRIPTION
Update all tests in TestH2Config to use the H2Configuration initializer
parameters and verify that attributes of that object indeed to get set
properly via those parameters.

This resolves #454.  Not sure if splitting these tests into two, one containing the constructor, and another containing the attribute modifications would be more appropriate here. 