### PR TITLE
Backport #476 to 2.6.X

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,14 @@
 Release History
 ===============
 
+2.6.1dev0
+---------
+
+Bugfixes
+~~~~~~~~
+
+- Allowed hyperframe v5 support while continuing to ignore unexpected frames.
+
 2.6.0 (2017-02-28)
 ------------------
 

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -28,8 +28,7 @@ from .events import (
 from .exceptions import (
     ProtocolError, NoSuchStreamError, FlowControlError, FrameTooLargeError,
     TooManyStreamsError, StreamClosedError, StreamIDTooLowError,
-    NoAvailableStreamIDError, UnsupportedFrameError, RFC1122Error,
-    DenialOfServiceError
+    NoAvailableStreamIDError, RFC1122Error, DenialOfServiceError
 )
 from .frame_buffer import FrameBuffer
 from .settings import Settings, SettingCodes
@@ -43,6 +42,15 @@ except ImportError:  # Platform-specific: HPACK < 2.3.0
     # If the exception doesn't exist, it cannot possibly be thrown. Define a
     # placeholder name, but don't otherwise worry about it.
     class OversizedHeaderListError(Exception):
+        pass
+
+
+try:
+    from hyperframe.frame import ExtensionFrame
+except ImportError:  # Platform-specific: Hyperframe < 5.0.0
+    # If the frame doesn't exist, that's just fine: we'll define it ourselves
+    # and the method will just never be called.
+    class ExtensionFrame(object):
         pass
 
 
@@ -404,6 +412,7 @@ class H2Connection(object):
             GoAwayFrame: self._receive_goaway_frame,
             ContinuationFrame: self._receive_naked_continuation,
             AltSvcFrame: self._receive_alt_svc_frame,
+            ExtensionFrame: self._receive_unknown_frame
         }
 
     def _prepare_for_sending(self, frames):
@@ -1575,10 +1584,6 @@ class H2Connection(object):
                 # Closed implicitly, also a connection error, but of type
                 # PROTOCOL_ERROR.
                 raise
-        except KeyError as e:  # pragma: no cover
-            # We don't have a function for handling this frame. Let's call this
-            # a PROTOCOL_ERROR and exit.
-            raise UnsupportedFrameError("Unexpected frame: %s" % frame)
         else:
             self._prepare_for_sending(frames)
 
@@ -1921,6 +1926,21 @@ class H2Connection(object):
             events.append(event)
 
         return frames, events
+
+    def _receive_unknown_frame(self, frame):
+        """
+        We have received a frame that we do not understand. This is almost
+        certainly an extension frame, though it's impossible to be entirely
+        sure.
+
+        RFC 7540 § 5.5 says that we MUST ignore unknown frame types: so we
+        do.
+        """
+        # All we do here is log.
+        self.config.logger.debug(
+            "Received unknown extension frame (ID %d)", frame.stream_id
+        )
+        return [], []
 
     def _local_settings_acked(self):
         """

--- a/h2/frame_buffer.py
+++ b/h2/frame_buffer.py
@@ -65,11 +65,13 @@ class FrameBuffer(object):
         """
         try:
             frame, length = Frame.parse_frame_header(data[:9])
-        except UnknownFrameError as e:
+        except UnknownFrameError as e:  # Platform-specific: Hyperframe < 5.0
             # Here we do something a bit odd. We want to consume the frame data
             # as consistently as possible, but we also don't ever want to yield
             # None. Instead, we make sure that, if there is no frame, we
             # recurse into ourselves.
+            # This can only happen now on older versions of hyperframe.
+            # TODO: Remove in 3.0
             length = e.length
             frame = None
         except ValueError as e:

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
     install_requires=[
-        'hyperframe>=3.1, <5, !=4.0.0',
+        'hyperframe>=3.1, <6, !=4.0.0',
         'hpack>=2.2, <3',
     ],
     extras_require={


### PR DESCRIPTION
Backports #476 to 2.6.X, without any interface changes.