### PR TITLE
Backport #476 to 2.5.X

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,11 @@ Release History
 2.5.3dev0
 ---------
 
+Bugfixes
+~~~~~~~~
+
+- Allowed hyperframe v5 support while continuing to ignore unexpected frames.
+
 
 2.5.2 (2017-01-27)
 ------------------

--- a/h2/frame_buffer.py
+++ b/h2/frame_buffer.py
@@ -65,11 +65,13 @@ class FrameBuffer(object):
         """
         try:
             frame, length = Frame.parse_frame_header(data[:9])
-        except UnknownFrameError as e:
+        except UnknownFrameError as e:  # Platform-specific: Hyperframe < 5.0
             # Here we do something a bit odd. We want to consume the frame data
             # as consistently as possible, but we also don't ever want to yield
             # None. Instead, we make sure that, if there is no frame, we
             # recurse into ourselves.
+            # This can only happen now on older versions of hyperframe.
+            # TODO: Remove in 3.0
             length = e.length
             frame = None
         except ValueError as e:

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
     install_requires=[
-        'hyperframe>=3.1, <5, !=4.0.0',
+        'hyperframe>=3.1, <6, !=4.0.0',
         'hpack>=2.2, <3',
     ],
     extras_require={


### PR DESCRIPTION
Backports #476 to 2.5.X, without any interface changes.