### PR TITLE
Fix up cookie handling.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,8 +1,17 @@
 Release History
 ===============
 
-2.7.0dev0
+3.0.0dev0
 ---------
+
+API Changes (Backward-Incompatible)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- By default, hyper-h2 now joins together received cookie header fields, per
+  RFC 7540 Section 8.1.2.5.
+- Added a ``normalize_inbound_headers`` flag to the ``H2Configuration`` object
+  that defaults to ``True``. Setting this to ``False`` changes the behaviour
+  from the previous point back to the v2 behaviour.
 
 API Changes (Backward-Compatible)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/h2/config.py
+++ b/h2/config.py
@@ -89,6 +89,15 @@ class H2Configuration(object):
         according to RFC 7540. Defaults to ``True``.
     :type validate_inbound_headers: ``bool``
 
+    :param normalize_inbound_headers: Controls whether the headers received by
+        this object are normalized according to the rules of RFC 7540.
+        Disabling this setting may lead to hyper-h2 emitting header blocks that
+        some RFCs forbid, e.g. with multiple cookie fields.
+
+        .. versionadded:: 3.0.0
+
+    :type normalize_inbound_headers: ``bool``
+
     :param logger: A logger that conforms to the requirements for this module,
         those being no I/O and no context switches, which is needed in order
         to run in asynchronous operation.
@@ -107,6 +116,9 @@ class H2Configuration(object):
     validate_inbound_headers = _BooleanConfigOption(
         'validate_inbound_headers'
     )
+    normalize_inbound_headers = _BooleanConfigOption(
+        'normalize_inbound_headers'
+    )
 
     def __init__(self,
                  client_side=True,
@@ -114,12 +126,14 @@ class H2Configuration(object):
                  validate_outbound_headers=True,
                  normalize_outbound_headers=True,
                  validate_inbound_headers=True,
+                 normalize_inbound_headers=True,
                  logger=None):
         self.client_side = client_side
         self.header_encoding = header_encoding
         self.validate_outbound_headers = validate_outbound_headers
         self.normalize_outbound_headers = normalize_outbound_headers
         self.validate_inbound_headers = validate_inbound_headers
+        self.normalize_inbound_headers = normalize_inbound_headers
         self.logger = logger or DummyLogger(__name__)
 
     @property

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -1064,8 +1064,9 @@ class H2Stream(object):
             headers = validate_headers(headers, hdr_validation_flags)
 
         if header_encoding:
-            headers = list(_decode_headers(headers, header_encoding))
-        events[0].headers = headers
+            headers = _decode_headers(headers, header_encoding)
+
+        events[0].headers = list(headers)
         return [], events
 
     def remotely_pushed(self, pushed_headers):
@@ -1118,9 +1119,11 @@ class H2Stream(object):
             headers = validate_headers(headers, hdr_validation_flags)
 
         if header_encoding:
-            headers = list(_decode_headers(headers, header_encoding))
+            headers = _decode_headers(headers, header_encoding)
 
-        events[0].headers = headers
+        # The above steps are all generators, so we need to concretize the
+        # headers now.
+        events[0].headers = list(headers)
         return [], events
 
     def receive_data(self, data, end_stream, flow_control_len):

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -27,7 +27,7 @@ from .exceptions import (
 from .utilities import (
     guard_increment_window, is_informational_response, authority_from_headers,
     validate_headers, validate_outbound_headers, normalize_outbound_headers,
-    HeaderValidationFlags, extract_method_header
+    HeaderValidationFlags, extract_method_header, normalize_inbound_headers
 )
 from .windows import WindowManager
 
@@ -1055,8 +1055,12 @@ class H2Stream(object):
         )
         events[0].pushed_stream_id = promised_stream_id
 
+        hdr_validation_flags = self._build_hdr_validation_flags(events)
+
+        if self.config.normalize_inbound_headers:
+            headers = normalize_inbound_headers(headers, hdr_validation_flags)
+
         if self.config.validate_inbound_headers:
-            hdr_validation_flags = self._build_hdr_validation_flags(events)
             headers = validate_headers(headers, hdr_validation_flags)
 
         if header_encoding:
@@ -1105,8 +1109,12 @@ class H2Stream(object):
             if not end_stream:
                 raise ProtocolError("Trailers must have END_STREAM set")
 
+        hdr_validation_flags = self._build_hdr_validation_flags(events)
+
+        if self.config.normalize_inbound_headers:
+            headers = normalize_inbound_headers(headers, hdr_validation_flags)
+
         if self.config.validate_inbound_headers:
-            hdr_validation_flags = self._build_hdr_validation_flags(events)
             headers = validate_headers(headers, hdr_validation_flags)
 
         if header_encoding:

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -1314,7 +1314,7 @@ class H2Stream(object):
                                   header_validation_flags,
                                   header_encoding):
         """
-        When headers have been received from the remote peer, runs a processing
+        When headers have been received from the remote peer, run a processing
         pipeline on them to transform them into the appropriate form for
         attaching to an event.
         """

--- a/h2/utilities.py
+++ b/h2/utilities.py
@@ -210,7 +210,7 @@ def validate_headers(headers, hdr_validation_flags):
         headers, hdr_validation_flags
     )
 
-    return list(headers)
+    return headers
 
 
 def _reject_uppercase_header_fields(headers, hdr_validation_flags):

--- a/test/test_basic_logic.py
+++ b/test/test_basic_logic.py
@@ -1727,6 +1727,41 @@ class TestBasicServer(object):
         else:
             pytest.mark.fail("Unable to check cookie header")
 
+    def test_cookies_arent_joined_without_normalization(self, frame_factory):
+        """
+        If inbound header normalization is disabled, cookie headers aren't
+        joined.
+        """
+        # This is a moderately varied set of cookie headers: some combined,
+        # some split.
+        cookie_headers = [
+            ('cookie',
+                'username=John Doe; expires=Thu, 18 Dec 2013 12:00:00 UTC'),
+            ('cookie', 'path=1'),
+            ('cookie', 'test1=val1; test2=val2')
+        ]
+
+        config = h2.config.H2Configuration(
+            client_side=False, normalize_inbound_headers=False
+        )
+        c = h2.connection.H2Connection(config=config)
+        c.initiate_connection()
+        c.receive_data(frame_factory.preamble())
+
+        f = frame_factory.build_headers_frame(
+            self.example_request_headers + cookie_headers
+        )
+        events = c.receive_data(f.serialize())
+
+        assert len(events) == 1
+        e = events[0]
+
+        cookie_field_count = sum(1 for n, _ in e.headers if n == 'cookie')
+        assert cookie_field_count == 3
+
+        received_cookies = [(n, v) for n, v in e.headers if n == 'cookie']
+        assert cookie_headers == received_cookies
+
     def test_stream_repr(self):
         """
         Ensure stream string representation is appropriate.

--- a/test/test_basic_logic.py
+++ b/test/test_basic_logic.py
@@ -882,15 +882,11 @@ class TestBasicClient(object):
         assert len(events) == 1
         e = events[0]
 
-        cookie_field_count = sum(1 for n, _ in e.headers if n == 'cookie')
-        assert cookie_field_count == 1
+        cookie_fields = [(n, v) for n, v in e.headers if n == 'cookie']
+        assert len(cookie_fields) == 1
 
-        for n, v in e.headers:
-            if n == 'cookie':
-                assert v == expected
-                break
-        else:
-            pytest.mark.fail("Unable to check cookie header")
+        _, v = cookie_fields[0]
+        assert v == expected
 
     def test_cookies_arent_joined_without_normalization(self, frame_factory):
         """
@@ -923,10 +919,8 @@ class TestBasicClient(object):
         assert len(events) == 1
         e = events[0]
 
-        cookie_field_count = sum(1 for n, _ in e.headers if n == 'cookie')
-        assert cookie_field_count == 3
-
         received_cookies = [(n, v) for n, v in e.headers if n == 'cookie']
+        assert len(received_cookies) == 3
         assert cookie_headers == received_cookies
 
 
@@ -1796,15 +1790,11 @@ class TestBasicServer(object):
         assert len(events) == 1
         e = events[0]
 
-        cookie_field_count = sum(1 for n, _ in e.headers if n == 'cookie')
-        assert cookie_field_count == 1
+        cookie_fields = [(n, v) for n, v in e.headers if n == 'cookie']
+        assert len(cookie_fields) == 1
 
-        for n, v in e.headers:
-            if n == 'cookie':
-                assert v == expected
-                break
-        else:
-            pytest.mark.fail("Unable to check cookie header")
+        _, v = cookie_fields[0]
+        assert v == expected
 
     def test_cookies_arent_joined_without_normalization(self, frame_factory):
         """
@@ -1835,10 +1825,8 @@ class TestBasicServer(object):
         assert len(events) == 1
         e = events[0]
 
-        cookie_field_count = sum(1 for n, _ in e.headers if n == 'cookie')
-        assert cookie_field_count == 3
-
         received_cookies = [(n, v) for n, v in e.headers if n == 'cookie']
+        assert len(received_cookies) == 3
         assert cookie_headers == received_cookies
 
     def test_stream_repr(self):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -28,7 +28,8 @@ class TestH2Config(object):
         'client_side',
         'validate_outbound_headers',
         'normalize_outbound_headers',
-        'validate_inbound_headers'
+        'validate_inbound_headers',
+        'normalize_inbound_headers',
     ]
 
     @pytest.mark.parametrize('option_name', boolean_config_options)

--- a/test/test_invalid_headers.py
+++ b/test/test_invalid_headers.py
@@ -451,7 +451,7 @@ class TestFilter(object):
     def test_invalid_pseudo_headers(self, hdr_validation_flags):
         headers = [(b':custom', b'value')]
         with pytest.raises(h2.exceptions.ProtocolError):
-            h2.utilities.validate_headers(headers, hdr_validation_flags)
+            list(h2.utilities.validate_headers(headers, hdr_validation_flags))
 
     @pytest.mark.parametrize('validation_function', validation_functions)
     @pytest.mark.parametrize(
@@ -471,9 +471,9 @@ class TestFilter(object):
             (b':method', b'GET'),
             (b'host', b'example.com'),
         ]
-        assert headers == h2.utilities.validate_headers(
+        assert headers == list(h2.utilities.validate_headers(
             headers, hdr_validation_flags
-        )
+        ))
 
     @pytest.mark.parametrize(
         'hdr_validation_flags', hdr_validation_response_headers
@@ -481,7 +481,7 @@ class TestFilter(object):
     def test_response_header_without_status(self, hdr_validation_flags):
         headers = [(b'content-length', b'42')]
         with pytest.raises(h2.exceptions.ProtocolError):
-            h2.utilities.validate_headers(headers, hdr_validation_flags)
+            list(h2.utilities.validate_headers(headers, hdr_validation_flags))
 
 
 class TestOversizedHeaders(object):


### PR DESCRIPTION
Resolves #497.

This is a breaking change, and I'd describe it as a moderately urgent one, so I'm hereby pronouncing that our next release will be 3.0. I'll be opening issues shortly to handle removing all deprecated functionality that needs to be stripped.