### PR TITLE
Expand MANIFEST.in to include basically everything.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ matrix:
       env: TOXENV=lint
     - python: "3.5"
       env: TOXENV=docs
+    - python: "2.7"
+      env: TOXENV=packaging
 
     # Test we haven't broken our major dependencies.
     - python: "2.7"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,7 @@
-include README.rst LICENSE CONTRIBUTORS.rst HISTORY.rst
-
+include README.rst LICENSE CONTRIBUTORS.rst HISTORY.rst tox.ini test_requirements.txt .coveragerc Makefile
+recursive-include test *.py
+graft docs
+prune docs/build
+graft visualizer
+recursive-include examples *.py *.crt *.key *.pem *.csr
+recursive-include utils *.sh

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, py36, pypy, lint, docs
+envlist = py27, py33, py34, py35, py36, pypy, lint, packaging, docs
 
 [testenv]
 deps= -r{toxinidir}/test_requirements.txt
@@ -43,3 +43,12 @@ basepython=python2.7
 deps = graphviz==0.6
 commands =
     python visualizer/visualize.py -i docs/source/_static
+
+[testenv:packaging]
+basepython=python2.7
+deps =
+    check-manifest==0.35
+    readme_renderer==17.2
+commands =
+    check-manifest
+    python setup.py check --metadata --restructuredtext --strict


### PR DESCRIPTION
Resolves #371.

Basically, @dstufft is of the view that the sdist should contain baaaaasically everything that is in the repo, except for things that literally cannot be used (e.g. no need for a .gitignore because this isn't a git repo, or a travis.yml). This patch does that.