### PR TITLE
Naked CONTINUATION frames must cause GOAWAY in all cases.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,14 @@ matrix:
       env: TOXENV=docs
     - python: "2.7"
       env: TOXENV=packaging
+    - python: "3.6"
+      env: TOXENV=h2spec
 
     # Test we haven't broken our major dependencies.
     - python: "2.7"
       env: TOXENV=py27-twistedMaster
 
 install:
-  - "pip install -U pip setuptools"
-  - "pip install -U tox"
+  - _travis/install.sh
 script:
   - tox -- --hypothesis-profile travis

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,10 @@ API Changes (Backward-Compatible)
 Bugfixes
 ~~~~~~~~
 
+- CONTINUATION frames sent on closed streams previously caused stream errors
+  of type STREAM_CLOSED. RFC 7540 requires that these be connection errors of
+  type PROTOCOL_ERROR, and so this release changes to match that behaviour.
+
 
 3.0.0 (2017-03-24)
 ------------------

--- a/_travis/install.sh
+++ b/_travis/install.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+pip install -U pip setuptools
+pip install -U tox
+
+if [ $TOXENV = "h2spec" ]; then
+    # We want to get the latest release of h2spec. We do that by asking the
+    # Github API for it, and then parsing the JSON for the appropriate kind of
+    # binary. Happily, the binary is always called "h2spec" so we don't need
+    # even more shenanigans to get this to work.
+    TARBALL=$(curl -s https://api.github.com/repos/summerwind/h2spec/releases/latest | jq '.assets[] | .browser_download_url | select(endswith("linux_amd64.tar.gz"))')
+    curl -LO "$TARBALL"
+    tar xvf $TARBALL
+    mv h2spec /usr/local/bin
+fi

--- a/_travis/install.sh
+++ b/_travis/install.sh
@@ -11,7 +11,7 @@ if [ $TOXENV = "h2spec" ]; then
     # Github API for it, and then parsing the JSON for the appropriate kind of
     # binary. Happily, the binary is always called "h2spec" so we don't need
     # even more shenanigans to get this to work.
-    TARBALL=$(curl -s https://api.github.com/repos/summerwind/h2spec/releases/latest | jq '.assets[] | .browser_download_url | select(endswith("linux_amd64.tar.gz"))')
+    TARBALL=$(curl -s https://api.github.com/repos/summerwind/h2spec/releases/latest | jq --raw-output '.assets[] | .browser_download_url | select(endswith("linux_amd64.tar.gz"))')
     curl -LO "$TARBALL"
     tar xvf $TARBALL
     mv h2spec /usr/local/bin

--- a/examples/asyncio/asyncio-server.py
+++ b/examples/asyncio/asyncio-server.py
@@ -8,10 +8,6 @@ A fully-functional HTTP/2 server using asyncio. Requires Python 3.5+.
 This example demonstrates handling requests with bodies, as well as handling
 those without. In particular, it demonstrates the fact that DataReceived may
 be called multiple times, and that applications must handle that possibility.
-
-Please note that this example does not handle flow control, and so only works
-properly for relatively small requests. Please see other examples to understand
-how flow control should work.
 """
 import asyncio
 import io
@@ -23,10 +19,11 @@ from typing import List, Tuple
 from h2.config import H2Configuration
 from h2.connection import H2Connection
 from h2.events import (
-    ConnectionTerminated, DataReceived, RequestReceived, StreamEnded
+    ConnectionTerminated, DataReceived, RequestReceived, StreamEnded,
+    StreamReset
 )
 from h2.errors import ErrorCodes
-from h2.exceptions import ProtocolError
+from h2.exceptions import ProtocolError, StreamClosedError
 
 
 RequestData = collections.namedtuple('RequestData', ['headers', 'data'])
@@ -38,11 +35,17 @@ class H2Protocol(asyncio.Protocol):
         self.conn = H2Connection(config=config)
         self.transport = None
         self.stream_data = {}
+        self.flow_control_futures = {}
 
     def connection_made(self, transport: asyncio.Transport):
         self.transport = transport
         self.conn.initiate_connection()
         self.transport.write(self.conn.data_to_send())
+
+    def connection_lost(self, exc):
+        for future in self.flow_control_futures.values():
+            future.cancel()
+        self.flow_control_futures = {}
 
     def data_received(self, data: bytes):
         try:
@@ -61,17 +64,14 @@ class H2Protocol(asyncio.Protocol):
                     self.stream_complete(event.stream_id)
                 elif isinstance(event, ConnectionTerminated):
                     self.transport.close()
+                elif isinstance(event, StreamReset):
+                    self.stream_reset(event.stream_id)
 
                 self.transport.write(self.conn.data_to_send())
 
     def request_received(self, headers: List[Tuple[str, str]], stream_id: int):
         headers = collections.OrderedDict(headers)
         method = headers[':method']
-
-        # We only support GET and POST.
-        if method not in ('GET', 'POST'):
-            self.return_405(headers, stream_id)
-            return
 
         # Store off the request data.
         request_data = RequestData(headers, io.BytesIO())
@@ -101,18 +101,7 @@ class H2Protocol(asyncio.Protocol):
             ('server', 'asyncio-h2'),
         )
         self.conn.send_headers(stream_id, response_headers)
-        self.conn.send_data(stream_id, data, end_stream=True)
-
-    def return_405(self, headers: List[Tuple[str, str]], stream_id: int):
-        """
-        We don't support the given method, so we want to return a 405 response.
-        """
-        response_headers = (
-            (':status', '405'),
-            ('content-length', '0'),
-            ('server', 'asyncio-h2'),
-        )
-        self.conn.send_headers(stream_id, response_headers, end_stream=True)
+        asyncio.ensure_future(self.send_data(data, stream_id))
 
     def receive_data(self, data: bytes, stream_id: int):
         """
@@ -127,6 +116,67 @@ class H2Protocol(asyncio.Protocol):
             )
         else:
             stream_data.data.write(data)
+
+    def stream_reset(self, stream_id):
+        """
+        A stream reset was sent. Stop sending data.
+        """
+        if stream_id in self.flow_control_futures:
+            future = self.flow_control_futures.pop(stream_id)
+            future.cancel()
+
+    async def send_data(self, data, stream_id):
+        """
+        Send data according to the flow control rules.
+        """
+        while data:
+            while not self.conn.local_flow_control_window(stream_id):
+                try:
+                    await self.wait_for_flow_control(stream_id)
+                except asyncio.CancelledError:
+                    return
+
+            chunk_size = min(
+                self.conn.local_flow_control_window(stream_id),
+                len(data),
+                self.conn.max_outbound_frame_size,
+            )
+
+            try:
+                self.conn.send_data(
+                    stream_id,
+                    data[:chunk_size],
+                    end_stream=(chunk_size == len(data))
+                )
+            except (StreamClosedError, ProtocolError):
+                # The stream got closed and we didn't get told. We're done
+                # here.
+                break
+
+            self.transport.write(self.conn.data_to_send())
+            data = data[chunk_size:]
+
+    async def wait_for_flow_control(self, stream_id):
+        """
+        Waits for a Future that fires when the flow control window is opened.
+        """
+        f = asyncio.Future()
+        self.flow_control_futures[stream_id] = f
+        await f
+
+    def window_updated(self, stream_id, delta):
+        """
+        A window update frame was received. Unblock some number of flow control
+        Futures.
+        """
+        if stream_id and stream_id in self.flow_control_futures:
+            f = self.flow_control_futures.pop(stream_id)
+            f.set_result(delta)
+        elif not stream_id:
+            for f in self.flow_control_futures.values():
+                f.set_result(delta)
+
+            self.flow_control_futures = {}
 
 
 ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)

--- a/examples/asyncio/asyncio-server.py
+++ b/examples/asyncio/asyncio-server.py
@@ -20,7 +20,7 @@ from h2.config import H2Configuration
 from h2.connection import H2Connection
 from h2.events import (
     ConnectionTerminated, DataReceived, RequestReceived, StreamEnded,
-    StreamReset
+    StreamReset, WindowUpdated
 )
 from h2.errors import ErrorCodes
 from h2.exceptions import ProtocolError, StreamClosedError
@@ -66,6 +66,8 @@ class H2Protocol(asyncio.Protocol):
                     self.transport.close()
                 elif isinstance(event, StreamReset):
                     self.stream_reset(event.stream_id)
+                elif isinstance(event, WindowUpdated):
+                    self.window_updated(event.stream_id, event.delta)
 
                 self.transport.write(self.conn.data_to_send())
 

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -684,8 +684,6 @@ _transitions = {
             StreamState.HALF_CLOSED_REMOTE),
     (StreamState.HALF_CLOSED_REMOTE, StreamInputs.RECV_PUSH_PROMISE):
         (H2StreamStateMachine.reset_stream_on_error, StreamState.CLOSED),
-    (StreamState.HALF_CLOSED_REMOTE, StreamInputs.RECV_CONTINUATION):
-        (H2StreamStateMachine.reset_stream_on_error, StreamState.CLOSED),
     (StreamState.HALF_CLOSED_REMOTE, StreamInputs.SEND_INFORMATIONAL_HEADERS):
         (H2StreamStateMachine.send_informational_response,
             StreamState.HALF_CLOSED_REMOTE),
@@ -738,8 +736,6 @@ _transitions = {
     (StreamState.CLOSED, StreamInputs.RECV_HEADERS):
         (H2StreamStateMachine.recv_on_closed_stream, StreamState.CLOSED),
     (StreamState.CLOSED, StreamInputs.RECV_DATA):
-        (H2StreamStateMachine.recv_on_closed_stream, StreamState.CLOSED),
-    (StreamState.CLOSED, StreamInputs.RECV_CONTINUATION):
         (H2StreamStateMachine.recv_on_closed_stream, StreamState.CLOSED),
 
     # > WINDOW_UPDATE or RST_STREAM frames can be received in this state

--- a/test/h2spectest.sh
+++ b/test/h2spectest.sh
@@ -16,4 +16,4 @@ popd
 sleep 2
 
 # Go go go!
-h2spec -k -t -v -p 8443
+h2spec -k -t -v -p 8443 $@

--- a/test/h2spectest.sh
+++ b/test/h2spectest.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# A test script that runs the example Python Twisted server and then runs
+# h2spec against it. Prints the output of h2spec. This script does not expect
+# to be run directly, but instead via `tox -e h2spec`.
+
+set -x
+
+# Kill all background jobs on exit.
+trap 'kill $(jobs -p)' EXIT
+
+pushd examples/asyncio
+python asyncio-server.py  &
+popd
+
+# Wait briefly to let the server start up
+sleep 2
+
+# Go go go!
+h2spec -k -t -v -p 8443

--- a/test/test_invalid_frame_sequences.py
+++ b/test/test_invalid_frame_sequences.py
@@ -160,8 +160,8 @@ class TestInvalidFrameSequences(object):
 
     def test_unexpected_continuation_on_closed_stream(self, frame_factory):
         """
-        CONTINUATION frames received on closed streams cause stream errors of
-        type STREAM_CLOSED.
+        CONTINUATION frames received on closed streams cause connection errors
+        of type PROTOCOL_ERROR.
         """
         c = h2.connection.H2Connection(config=self.server_config)
         c.initiate_connection()
@@ -177,11 +177,13 @@ class TestInvalidFrameSequences(object):
         bad_frame = frame_factory.build_continuation_frame(
             header_block=b'hello'
         )
-        c.receive_data(bad_frame.serialize())
 
-        expected_frame = frame_factory.build_rst_stream_frame(
-            stream_id=1,
-            error_code=0x5,
+        with pytest.raises(h2.exceptions.ProtocolError):
+            c.receive_data(bad_frame.serialize())
+
+        expected_frame = frame_factory.build_goaway_frame(
+            error_code=h2.errors.ErrorCodes.PROTOCOL_ERROR,
+            last_stream_id=1
         )
         assert c.data_to_send() == expected_frame.serialize()
 

--- a/tox.ini
+++ b/tox.ini
@@ -58,4 +58,4 @@ basepython=python3.6
 deps = twisted[tls]==17.1.0
 whitelist_externals = {toxinidir}/test/h2spectest.sh
 commands =
-    {toxinidir}/test/h2spectest.sh
+    {toxinidir}/test/h2spectest.sh {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -52,3 +52,10 @@ deps =
 commands =
     check-manifest
     python setup.py check --metadata --restructuredtext --strict
+
+[testenv:h2spec]
+basepython=python3.6
+deps = twisted[tls]==17.1.0
+whitelist_externals = {toxinidir}/test/h2spectest.sh
+commands =
+    {toxinidir}/test/h2spectest.sh


### PR DESCRIPTION
Spotted with h2spec.

Our logic for handling frames on closed streams was overriding the logic for naked CONTINUATION frames. RFC 7540 requires that naked CONTINUATION frames always be treated as connection errors, but we were treating them as stream errors that boiled down to "receiving on a closed stream". That's wrong, so we need to fix it.