### PR TITLE
Naked CONTINUATION frames must cause GOAWAY.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,11 @@ API Changes (Backward-Compatible)
 Bugfixes
 ~~~~~~~~
 
+- CONTINUATION frames sent on closed streams previously caused stream errors
+  of type STREAM_CLOSED. RFC 7540 § 6.10 requires that these be connection
+  errors of type PROTOCOL_ERROR, and so this release changes to match that
+  behaviour.
+
 
 3.0.0 (2017-03-24)
 ------------------

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -684,8 +684,6 @@ _transitions = {
             StreamState.HALF_CLOSED_REMOTE),
     (StreamState.HALF_CLOSED_REMOTE, StreamInputs.RECV_PUSH_PROMISE):
         (H2StreamStateMachine.reset_stream_on_error, StreamState.CLOSED),
-    (StreamState.HALF_CLOSED_REMOTE, StreamInputs.RECV_CONTINUATION):
-        (H2StreamStateMachine.reset_stream_on_error, StreamState.CLOSED),
     (StreamState.HALF_CLOSED_REMOTE, StreamInputs.SEND_INFORMATIONAL_HEADERS):
         (H2StreamStateMachine.send_informational_response,
             StreamState.HALF_CLOSED_REMOTE),
@@ -738,8 +736,6 @@ _transitions = {
     (StreamState.CLOSED, StreamInputs.RECV_HEADERS):
         (H2StreamStateMachine.recv_on_closed_stream, StreamState.CLOSED),
     (StreamState.CLOSED, StreamInputs.RECV_DATA):
-        (H2StreamStateMachine.recv_on_closed_stream, StreamState.CLOSED),
-    (StreamState.CLOSED, StreamInputs.RECV_CONTINUATION):
         (H2StreamStateMachine.recv_on_closed_stream, StreamState.CLOSED),
 
     # > WINDOW_UPDATE or RST_STREAM frames can be received in this state

--- a/test/test_invalid_frame_sequences.py
+++ b/test/test_invalid_frame_sequences.py
@@ -160,8 +160,8 @@ class TestInvalidFrameSequences(object):
 
     def test_unexpected_continuation_on_closed_stream(self, frame_factory):
         """
-        CONTINUATION frames received on closed streams cause stream errors of
-        type STREAM_CLOSED.
+        CONTINUATION frames received on closed streams cause connection errors
+        of type PROTOCOL_ERROR.
         """
         c = h2.connection.H2Connection(config=self.server_config)
         c.initiate_connection()
@@ -177,11 +177,13 @@ class TestInvalidFrameSequences(object):
         bad_frame = frame_factory.build_continuation_frame(
             header_block=b'hello'
         )
-        c.receive_data(bad_frame.serialize())
 
-        expected_frame = frame_factory.build_rst_stream_frame(
-            stream_id=1,
-            error_code=0x5,
+        with pytest.raises(h2.exceptions.ProtocolError):
+            c.receive_data(bad_frame.serialize())
+
+        expected_frame = frame_factory.build_goaway_frame(
+            error_code=h2.errors.ErrorCodes.PROTOCOL_ERROR,
+            last_stream_id=1
         )
         assert c.data_to_send() == expected_frame.serialize()
 


### PR DESCRIPTION
Spotted with h2spec.

Our logic for handling frames on closed streams was overriding the logic for naked CONTINUATION frames. RFC 7540 requires that naked CONTINUATION frames always be treated as connection errors, but we were treating them as stream errors that boiled down to "receiving on a closed stream". That's wrong, so we need to fix it.