### PR TITLE
Turn flow control errors on the stream into stream-level errors.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,10 @@ API Changes (Backward-Compatible)
 Bugfixes
 ~~~~~~~~
 
+- Remote peers incrementing their inbound connection window beyond the maximum
+  allowed value now cause stream-level errors, rather than connection-level
+  errors, allowing connections to stay up longer.
+
 
 3.0.0 (2017-03-24)
 ------------------

--- a/test/test_flow_control_window.py
+++ b/test/test_flow_control_window.py
@@ -528,11 +528,17 @@ class TestFlowControl(object):
             stream_id=1, increment=increment
         )
 
-        with pytest.raises(h2.exceptions.FlowControlError):
-            c.receive_data(f.serialize())
+        events = c.receive_data(f.serialize())
+        assert len(events) == 1
 
-        expected_frame = frame_factory.build_goaway_frame(
-            last_stream_id=0,
+        event = events[0]
+        assert isinstance(event, h2.events.StreamReset)
+        assert event.stream_id == 1
+        assert event.error_code == h2.errors.ErrorCodes.FLOW_CONTROL_ERROR
+        assert not event.remote_reset
+
+        expected_frame = frame_factory.build_rst_stream_frame(
+            stream_id=0,
             error_code=h2.errors.ErrorCodes.FLOW_CONTROL_ERROR,
         )
         assert c.data_to_send() == expected_frame.serialize()

--- a/test/test_flow_control_window.py
+++ b/test/test_flow_control_window.py
@@ -538,7 +538,7 @@ class TestFlowControl(object):
         assert not event.remote_reset
 
         expected_frame = frame_factory.build_rst_stream_frame(
-            stream_id=0,
+            stream_id=1,
             error_code=h2.errors.ErrorCodes.FLOW_CONTROL_ERROR,
         )
         assert c.data_to_send() == expected_frame.serialize()


### PR DESCRIPTION
Resolves #507.