### PR TITLE
Improve handling of request pseudo header fields.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,11 @@ API Changes (Backward-Compatible)
 Bugfixes
 ~~~~~~~~
 
+- h2 now rejects receiving and sending request header blocks that are missing
+  any of the mandatory pseudo-header fields (:path, :scheme, and :method).
+- h2 now rejects receiving and sending request header blocks that have an empty
+  :path pseudo-header value.
+
 
 3.0.0 (2017-03-24)
 ------------------

--- a/h2/utilities.py
+++ b/h2/utilities.py
@@ -209,6 +209,7 @@ def validate_headers(headers, hdr_validation_flags):
     headers = _check_host_authority_header(
         headers, hdr_validation_flags
     )
+    headers = _check_path_header(headers, hdr_validation_flags)
 
     return headers
 
@@ -434,6 +435,32 @@ def _check_host_authority_header(headers, hdr_validation_flags):
     return _validate_host_authority_header(headers)
 
 
+def _check_path_header(headers, hdr_validation_flags):
+    """
+    Raise a ProtocolError if a header block arrives or is sent that contains an
+    empty :path header.
+    """
+    def inner():
+        for header in headers:
+            if header[0] in (b':path', u':path'):
+                if not header[1]:
+                    raise ProtocolError("An empty :path header is forbidden")
+
+            yield header
+
+    # We only expect to see :authority and Host headers on request header
+    # blocks that aren't trailers, so skip this validation if this is a
+    # response header or we're looking at trailer blocks.
+    skip_validation = (
+        hdr_validation_flags.is_response_header or
+        hdr_validation_flags.is_trailer
+    )
+    if skip_validation:
+        return headers
+    else:
+        return inner()
+
+
 def _lowercase_header_names(headers, hdr_validation_flags):
     """
     Given an iterable of header two-tuples, rebuilds that iterable with the
@@ -557,5 +584,6 @@ def validate_outbound_headers(headers, hdr_validation_flags):
     headers = _check_sent_host_authority_header(
         headers, hdr_validation_flags
     )
+    headers = _check_path_header(headers, hdr_validation_flags)
 
     return headers

--- a/test/test_basic_logic.py
+++ b/test/test_basic_logic.py
@@ -492,6 +492,9 @@ class TestBasicClient(object):
         )
         test_headers = [
             (':authority', 'example.com'),
+            (':path', '/'),
+            (':method', 'GET'),
+            (':scheme', 'https'),
             ('key', large_binary_string)
         ]
         c = h2.connection.H2Connection()
@@ -1169,7 +1172,13 @@ class TestBasicServer(object):
         c = h2.connection.H2Connection(config=self.server_config)
         c.receive_data(frame_factory.preamble())
         headers_frame = frame_factory.build_headers_frame(
-            [(':authority', 'example.com')], stream_id=23)
+            [
+                (':authority', 'example.com'),
+                (':path', '/'),
+                (':scheme', 'https'),
+                (':method', 'GET'),
+            ],
+            stream_id=23)
         c.receive_data(headers_frame.serialize())
 
         f = frame_factory.build_goaway_frame(

--- a/test/test_invalid_headers.py
+++ b/test/test_invalid_headers.py
@@ -439,6 +439,61 @@ class TestFilter(object):
         if not (flags.is_trailer or flags.is_response_header)
     ]
 
+    invalid_request_header_blocks_bytes = (
+        # First, missing :method
+        (
+            (b':authority', b'google.com'),
+            (b':path', b'/'),
+            (b':scheme', b'https'),
+        ),
+        # Next, missing :path
+        (
+            (b':authority', b'google.com'),
+            (b':method', b'GET'),
+            (b':scheme', b'https'),
+        ),
+        # Next, missing :scheme
+        (
+            (b':authority', b'google.com'),
+            (b':method', b'GET'),
+            (b':path', b'/'),
+        ),
+        # Finally, path present but empty.
+        (
+            (b':authority', b'google.com'),
+            (b':method', b'GET'),
+            (b':scheme', b'https'),
+            (b':path', b''),
+        ),
+    )
+    invalid_request_header_blocks_unicode = (
+        # First, missing :method
+        (
+            (u':authority', u'google.com'),
+            (u':path', u'/'),
+            (u':scheme', u'https'),
+        ),
+        # Next, missing :path
+        (
+            (u':authority', u'google.com'),
+            (u':method', u'GET'),
+            (u':scheme', u'https'),
+        ),
+        # Next, missing :scheme
+        (
+            (u':authority', u'google.com'),
+            (u':method', u'GET'),
+            (u':path', u'/'),
+        ),
+        # Finally, path present but empty.
+        (
+            (u':authority', u'google.com'),
+            (u':method', u'GET'),
+            (u':scheme', u'https'),
+            (u':path', u''),
+        ),
+    )
+
     @pytest.mark.parametrize('validation_function', validation_functions)
     @pytest.mark.parametrize('hdr_validation_flags', hdr_validation_combos)
     @given(headers=HEADERS_STRATEGY)
@@ -491,6 +546,42 @@ class TestFilter(object):
         headers = [(b'content-length', b'42')]
         with pytest.raises(h2.exceptions.ProtocolError):
             list(h2.utilities.validate_headers(headers, hdr_validation_flags))
+
+    @pytest.mark.parametrize(
+        'hdr_validation_flags', hdr_validation_request_headers_no_trailer
+    )
+    @pytest.mark.parametrize(
+        'header_block',
+        (
+            invalid_request_header_blocks_bytes +
+            invalid_request_header_blocks_unicode
+        )
+    )
+    def test_outbound_req_header_missing_pseudo_headers(self,
+                                                        hdr_validation_flags,
+                                                        header_block):
+        with pytest.raises(h2.exceptions.ProtocolError):
+            list(
+                h2.utilities.validate_outbound_headers(
+                    header_block, hdr_validation_flags
+                )
+            )
+
+    @pytest.mark.parametrize(
+        'hdr_validation_flags', hdr_validation_request_headers_no_trailer
+    )
+    @pytest.mark.parametrize(
+        'header_block', invalid_request_header_blocks_bytes
+    )
+    def test_inbound_req_header_missing_pseudo_headers(self,
+                                                       hdr_validation_flags,
+                                                       header_block):
+        with pytest.raises(h2.exceptions.ProtocolError):
+            list(
+                h2.utilities.validate_headers(
+                    header_block, hdr_validation_flags
+                )
+            )
 
 
 class TestOversizedHeaders(object):


### PR DESCRIPTION
This resolves most of the points in #510 by validating that the request pseudo-header fields are present-and-correct in request headers.