### PR TITLE
Prevent pseudo-headers appearing in incorrect contexts.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,8 @@ Bugfixes
   any of the mandatory pseudo-header fields (:path, :scheme, and :method).
 - h2 now rejects receiving and sending request header blocks that have an empty
   :path pseudo-header value.
+- h2 now rejects receiving and sending request header blocks that contain
+  response-only pseudo-headers, and vice versa.
 
 
 3.0.0 (2017-03-24)


### PR DESCRIPTION
Resolves #510.

This prevents `:status` appearing in request header blocks and the various request pseudo-headers appearing in response header blocks.