### PR TITLE
Add missing terminator to backport script.

### DIFF
--- a/utils/backport.sh
+++ b/utils/backport.sh
@@ -16,6 +16,7 @@ fi
 if ! git pull --ff-only; then
     echo "Unable to update $TARGET_BRANCH"
     exit 2
+fi
 
 if ! git checkout -b "$PR_BRANCH"; then
     echo "Failed to open new branch $PR_BRANCH"


### PR DESCRIPTION
I have no idea where this went, as I have used the backport script successfully in the past, but...somehow I lost a `fi`.