### PR TITLE
Limit which travis branches are built.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 sudo: false
 language: python
 
+branches:
+  only:
+    - master
+    - /^\d+\.\d+\.X$/
+
 cache:
   directories:
     - $HOME/.cache/pip


### PR DESCRIPTION
This should help reduce the impact of #561 by preventing travis from feeling like it needs to build PR branches twice: once for the PR and once for the branch itself.