### PR TITLE
Fixed logging TypeError when stream_id is None

### DIFF
--- a/h2/connection.py
+++ b/h2/connection.py
@@ -909,16 +909,21 @@ class H2Connection(object):
             frames = stream.increase_flow_control_window(
                 increment
             )
+
+            self.config.logger.debug(
+                "Increase stream ID %d flow control window by %d",
+                stream_id, increment
+            )
         else:
             self._inbound_flow_control_window_manager.window_opened(increment)
             f = WindowUpdateFrame(0)
             f.window_increment = increment
             frames = [f]
 
-        self.config.logger.debug(
-            "Increase stream ID %d flow control window by %d",
-            stream_id, increment
-        )
+            self.config.logger.debug(
+                "Increase connection flow control window by %d", increment
+            )
+
         self._prepare_for_sending(frames)
 
     def push_stream(self, stream_id, promised_stream_id, request_headers):


### PR DESCRIPTION
When trying to increment the connection flow control window, with logging level debug, the following error is logged:

```python
Traceback (most recent call last):
  File "/usr/lib/python2.7/logging/__init__.py", line 861, in emit
    msg = self.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 734, in format
    return fmt.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 465, in format
    record.message = record.getMessage()
  File "/usr/lib/python2.7/logging/__init__.py", line 329, in getMessage
    msg = msg % self.args
TypeError: %d format: a number is required, not NoneType
```
