### PR TITLE
data_to_send: bytes -> bytearray

### DIFF
--- a/h2/connection.py
+++ b/h2/connection.py
@@ -350,7 +350,7 @@ class H2Connection(object):
         self._header_frames = []
 
         # Data that needs to be sent.
-        self._data_to_send = b''
+        self._data_to_send = bytearray()
 
         # Keeps track of how streams are closed.
         # Used to ensure that we don't blow up in the face of frames that were
@@ -1353,11 +1353,11 @@ class H2Connection(object):
         :rtype: ``bytes``
         """
         if amount is None:
-            data = self._data_to_send
-            self._data_to_send = b''
+            data = bytes(self._data_to_send)
+            self._data_to_send = bytearray()
             return data
         else:
-            data = self._data_to_send[:amount]
+            data = bytes(self._data_to_send[:amount])
             self._data_to_send = self._data_to_send[amount:]
             return data
 
@@ -1371,7 +1371,7 @@ class H2Connection(object):
         This method should not normally be used, but is made available to avoid
         exposing implementation details.
         """
-        self._data_to_send = b''
+        self._data_to_send = bytearray()
 
     def _acknowledge_settings(self):
         """


### PR DESCRIPTION
This PR changes internal `H2Connection._data_to_send` buffer type from `bytes` to `bytearray` to avoid quadratic behaviour. I observed this in some internal tests of my [pure Python gRPC framework](https://github.com/standy66/purerpc). Changing `bytes` to `bytearray` sped up things significantly (in some test by a factor of 10). Here is shrunk down example:
```python
import time

CHUNK = b'\x00' * 128
LOG_NUM_CHUNKS = range(10, 17, 1)


def test(num_chunks, use_bytearray=False):
    data = bytearray() if use_bytearray else b''
    start = time.time()
    for i in range(num_chunks):
        data += CHUNK
    took = time.time() - start
    print("{}, {} chunks: {} s".format("bytearray" if use_bytearray else "bytes", num_chunks, took))

for log_num_chunks in LOG_NUM_CHUNKS:
    test(2 ** log_num_chunks, True)

for log_num_chunks in LOG_NUM_CHUNKS:
    test(2 ** log_num_chunks, False)
```
Output:
```
bytearray, 1024 chunks: 0.0003352165222167969 s
bytearray, 2048 chunks: 0.0004980564117431641 s
bytearray, 4096 chunks: 0.0007932186126708984 s
bytearray, 8192 chunks: 0.0015578269958496094 s
bytearray, 16384 chunks: 0.0022699832916259766 s
bytearray, 32768 chunks: 0.004495859146118164 s
bytearray, 65536 chunks: 0.009869098663330078 s
bytes, 1024 chunks: 0.0027780532836914062 s
bytes, 2048 chunks: 0.013530969619750977 s
bytes, 4096 chunks: 0.0653691291809082 s
bytes, 8192 chunks: 0.27916908264160156 s
bytes, 16384 chunks: 1.2396430969238281 s
bytes, 32768 chunks: 7.641407012939453 s
bytes, 65536 chunks: 50.12349009513855 s
```