### PR TITLE
Remove twisted CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,6 @@ matrix:
       dist: xenial
       env: TOXENV=packaging
 
-    # Test we haven't broken our major dependencies.
-    - python: "2.7"
-      dist: trusty
-      env: TOXENV=py27-twistedMaster
 install:
   - "pip install -U pip setuptools"
   - "pip install -U tox"

--- a/tox.ini
+++ b/tox.ini
@@ -11,15 +11,6 @@ commands=
 # temporarily disable coverage testing on PyPy due to performance problems
 commands= py.test {posargs} {toxinidir}/test/
 
-[testenv:py27-twistedMaster]
-# This is a validation test that confirms that Twisted's test cases haven't
-# broken.
-deps =
-    cryptography==2.4.2
-    twisted[tls, http2, conch]
-    sphinx
-commands = python -m twisted.trial --reporter=text twisted
-
 [testenv:lint]
 basepython=python3.7
 deps = flake8==3.5.0


### PR DESCRIPTION
This has been broken for a while (due to a Twisted update), and I've
insufficient Twisted knowledge to fix it. I understand from @Lukasa
that this can safely be removed.

I'll leave this open for at least a week in case someone else knows better.