### PR TITLE
Update url in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,8 @@ setup(
     author_email='cory@lukasa.co.uk',
     url='https://github.com/python-hyper/hyper-h2',
     project_urls={
-        'Documentation': 'https://python-hyper.org/projects/h2/',
-        'Source': 'https://github.com/python-hyper/hyper-h2/',
+        'Documentation': 'https://python-hyper.org/projects/h2',
+        'Source': 'https://github.com/python-hyper/hyper-h2',
     },
     packages=packages,
     package_data={'': ['LICENSE', 'README.rst', 'CONTRIBUTORS.rst', 'HISTORY.rst', 'NOTICES']},

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,11 @@ setup(
     long_description=u'\n\n'.join([readme, history]),
     author='Cory Benfield',
     author_email='cory@lukasa.co.uk',
-    url='http://hyper.rtfd.org',
+    url='https://github.com/python-hyper/hyper-h2',
+    project_urls={
+        'Documentation': 'https://python-hyper.org/projects/h2/',
+        'Source': 'https://github.com/python-hyper/hyper-h2/',
+    },
     packages=packages,
     package_data={'': ['LICENSE', 'README.rst', 'CONTRIBUTORS.rst', 'HISTORY.rst', 'NOTICES']},
     package_dir={'h2': 'h2'},


### PR DESCRIPTION
Hi :wave: I wanted to check out the `h2` package since httpx [mentioned](https://github.com/encode/httpx#dependencies) it. By following the URL on [PyPI](https://pypi.org/project/h2/) I found the repo https://github.com/python-hyper/hyper and was confused that the last commit was back in 2017.

So here is a PR that updates the URL, so people coming from PyPI will find the right repo and the right docs :blush: I chose the repo URL over the documentation URL, since it's very easy to get to the documentation from the repo, but not as easy to get to the repo from the documentation.