### PR TITLE
ignore WINDOW_UPDATE frames on removed or non-existent stream

### DIFF
--- a/h2/connection.py
+++ b/h2/connection.py
@@ -1739,7 +1739,7 @@ class H2Connection(object):
                     frame.window_increment
                 )
             except StreamClosedError:
-                return [], []
+                return [], events
         else:
             # Increment our local flow control window.
             self.outbound_flow_control_window = guard_increment_window(

--- a/h2/connection.py
+++ b/h2/connection.py
@@ -1733,10 +1733,13 @@ class H2Connection(object):
         )
 
         if frame.stream_id:
-            stream = self._get_stream_by_id(frame.stream_id)
-            frames, stream_events = stream.receive_window_update(
-                frame.window_increment
-            )
+            try:
+                stream = self._get_stream_by_id(frame.stream_id)
+                frames, stream_events = stream.receive_window_update(
+                    frame.window_increment
+                )
+            except StreamClosedError:
+                return [], []
         else:
             # Increment our local flow control window.
             self.outbound_flow_control_window = guard_increment_window(

--- a/test/test_closed_streams.py
+++ b/test/test_closed_streams.py
@@ -186,6 +186,7 @@ class TestClosedStreams(object):
         events = c.receive_data(window_update_frame.serialize())
         assert not events
 
+
 class TestStreamsClosedByEndStream(object):
     example_request_headers = [
         (':authority', 'example.com'),

--- a/test/test_closed_streams.py
+++ b/test/test_closed_streams.py
@@ -178,6 +178,13 @@ class TestClosedStreams(object):
         events = c.receive_data(window_update_frame.serialize())
         assert not events
 
+        # Getting open_inbound_streams property will trigger stream accounting
+        # which results in removing closed streams.
+        c.open_inbound_streams
+
+        # Another window_update_frame is received for stream 1
+        events = c.receive_data(window_update_frame.serialize())
+        assert not events
 
 class TestStreamsClosedByEndStream(object):
     example_request_headers = [


### PR DESCRIPTION
This pull request fixes an issue with receiving `WINDOW_UPDATE` frames on streams that have been closed and removed - which could happen while opening a new stream.

Please let me know if anything should be done differently. Here are some doubts I have about this approach:

1. This code will also ignore streams that have never been created. Maybe checking in `_closed_streams` as well would be better.
2. Maybe a separate test would make more sense.