### PR TITLE
Raise a ProtocolError if we receive data before headers

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,7 @@ API Changes (Backward-Incompatible)
 - Support for Python 3.4 has been removed.
 - Support for Python 3.5 has been removed.
 - Support for PyPy (Python 2.7 compatible) has been removed.
+- Receiving DATA before HEADERS now raises a ProtocolError.
 
 
 3.2.0 (2020-02-08)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,7 +11,7 @@ API Changes (Backward-Incompatible)
 - Support for Python 3.4 has been removed.
 - Support for Python 3.5 has been removed.
 - Support for PyPy (Python 2.7 compatible) has been removed.
-- Receiving DATA before HEADERS now raises a ProtocolError.
+- Receiving DATA before HEADERS now raises a ProtocolError (see https://tools.ietf.org/html/rfc7540#section-8.1)
 
 
 3.2.0 (2020-02-08)

--- a/h2/stream.py
+++ b/h2/stream.py
@@ -198,6 +198,8 @@ class H2StreamStateMachine(object):
         """
         Fires when data is received.
         """
+        if not self.headers_received:
+            raise ProtocolError("cannot receive data before headers")
         event = DataReceived()
         event.stream_id = self.stream_id
         return [event]

--- a/test/test_invalid_frame_sequences.py
+++ b/test/test_invalid_frame_sequences.py
@@ -31,6 +31,7 @@ class TestInvalidFrameSequences(object):
         ('server', 'fake-serv/0.1.0')
     ]
     server_config = h2.config.H2Configuration(client_side=False)
+    client_config = h2.config.H2Configuration(client_side=True)
 
     def test_cannot_send_on_closed_stream(self):
         """
@@ -278,6 +279,23 @@ class TestInvalidFrameSequences(object):
             c.receive_data(frame_data)
 
         assert "Stream ID must be non-zero" in str(e.value)
+
+    def test_data_before_headers(self, frame_factory):
+        """
+        When data frames are received before headers
+        they cause ProtocolErrors to be raised.
+        """
+        c = h2.connection.H2Connection(config=self.client_config)
+        c.initiate_connection()
+        # transition stream into OPEN
+        c.send_headers(1, self.example_request_headers)
+
+        f = frame_factory.build_data_frame(b"hello")
+
+        with pytest.raises(h2.exceptions.ProtocolError) as e:
+            c.receive_data(f.serialize())
+
+        assert "cannot receive data before headers" in str(e.value)
 
     def test_get_stream_reset_event_on_auto_reset(self, frame_factory):
         """


### PR DESCRIPTION
This PR tightens hyper-h2's sanity checks and raises a ProtocolError if we receive a data frame on a stream before we receive response headers.