### PR TITLE
fix protocol errors with newer hyperframe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
     install_requires=[
-        'hyperframe>=5.2.0,<6',
+        'hyperframe>=6.0,<7',
         'hpack>=4.0,<5',
     ],
 )

--- a/src/h2/connection.py
+++ b/src/h2/connection.py
@@ -1721,12 +1721,8 @@ class H2Connection:
         """
         Receive a WINDOW_UPDATE frame on the connection.
         """
-        # Validate the frame.
-        if not (1 <= frame.window_increment <= self.MAX_WINDOW_INCREMENT):
-            raise ProtocolError(
-                "Flow control increment must be between 1 and %d, received %d"
-                % (self.MAX_WINDOW_INCREMENT, frame.window_increment)
-            )
+        # hyperframe will take care of validating the window_increment.
+        # If we reach in here, we can assume a valid value.
 
         events = self.state_machine.process_input(
             ConnectionInputs.RECV_WINDOW_UPDATE

--- a/src/h2/exceptions.py
+++ b/src/h2/exceptions.py
@@ -26,7 +26,7 @@ class FrameTooLargeError(ProtocolError):
     """
     The frame that we tried to send or that we received was too large.
     """
-    #: This error code that corresponds to this kind of Protocol Error.
+    #: The error code corresponds to this kind of Protocol Error.
     error_code = h2.errors.ErrorCodes.FRAME_SIZE_ERROR
 
 
@@ -36,7 +36,7 @@ class FrameDataMissingError(ProtocolError):
 
     .. versionadded:: 2.0.0
     """
-    #: The error code that corresponds to this kind of Protocol Error
+    #: The error code corresponds to this kind of Protocol Error.
     error_code = h2.errors.ErrorCodes.FRAME_SIZE_ERROR
 
 
@@ -52,8 +52,7 @@ class FlowControlError(ProtocolError):
     """
     An attempted action violates flow control constraints.
     """
-    #: The error code that corresponds to this kind of
-    #: :class:`ProtocolError <h2.exceptions.ProtocolError>`
+    #: The error code corresponds to this kind of Protocol Error.
     error_code = h2.errors.ErrorCodes.FLOW_CONTROL_ERROR
 
 
@@ -94,7 +93,7 @@ class NoSuchStreamError(ProtocolError):
        <h2.exceptions.ProtocolError>`
     """
     def __init__(self, stream_id):
-        #: The stream ID that corresponds to the non-existent stream.
+        #: The stream ID corresponds to the non-existent stream.
         self.stream_id = stream_id
 
 
@@ -106,7 +105,7 @@ class StreamClosedError(NoSuchStreamError):
     stream has been removed.
     """
     def __init__(self, stream_id):
-        #: The stream ID that corresponds to the nonexistent stream.
+        #: The stream ID corresponds to the nonexistent stream.
         self.stream_id = stream_id
 
         #: The relevant HTTP/2 error code.
@@ -145,13 +144,15 @@ class InvalidBodyLengthError(ProtocolError):
         )
 
 
-class UnsupportedFrameError(ProtocolError, KeyError):
+class UnsupportedFrameError(ProtocolError):
     """
     The remote peer sent a frame that is unsupported in this context.
 
     .. versionadded:: 2.1.0
+
+    .. versionchanged:: 4.0.0
+       Removed deprecated KeyError parent class.
     """
-    # TODO: Remove the KeyError in 3.0.0
     pass
 
 
@@ -181,6 +182,6 @@ class DenialOfServiceError(ProtocolError):
 
     .. versionadded:: 2.5.0
     """
-    #: The error code that corresponds to this kind of
+    #: The error code corresponds to this kind of
     #: :class:`ProtocolError <h2.exceptions.ProtocolError>`
     error_code = h2.errors.ErrorCodes.ENHANCE_YOUR_CALM

--- a/test/test_invalid_frame_sequences.py
+++ b/test/test_invalid_frame_sequences.py
@@ -278,7 +278,7 @@ class TestInvalidFrameSequences(object):
         with pytest.raises(h2.exceptions.ProtocolError) as e:
             c.receive_data(frame_data)
 
-        assert "Stream ID must be non-zero" in str(e.value)
+        assert "Received frame with invalid header" in str(e.value)
 
     def test_data_before_headers(self, frame_factory):
         """


### PR DESCRIPTION
see https://github.com/python-hyper/hyperframe/pull/151

This PR bumps hyperframe to the freshly released v6.0.0.