### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/src/h2/connection.py
+++ b/src/h2/connection.py
@@ -780,7 +780,7 @@ class H2Connection:
             on the stream given in ``priority_depends_on`` for priority
             purposes. See :meth:`prioritize
             <h2.connection.H2Connection.prioritize>` for more about how this
-            field workds. Defaults to ``None``, which means that no priority
+            field works. Defaults to ``None``, which means that no priority
             information will be sent.
         :type priority_depends_on: ``bool`` or ``None``
 

--- a/src/h2/events.py
+++ b/src/h2/events.py
@@ -510,7 +510,7 @@ class SettingsAcknowledged(Event):
     """
     The SettingsAcknowledged event is fired whenever a settings ACK is received
     from the remote peer. The event carries on it the settings that were
-    acknowedged, in the same format as
+    acknowledged, in the same format as
     :class:`h2.events.RemoteSettingsChanged`.
     """
 

--- a/src/h2/frame_buffer.py
+++ b/src/h2/frame_buffer.py
@@ -13,7 +13,7 @@ from hyperframe.frame import ContinuationFrame, Frame, HeadersFrame, PushPromise
 from .exceptions import FrameDataMissingError, FrameTooLargeError, ProtocolError
 
 # To avoid a DOS attack based on sending loads of continuation frames, we limit
-# the maximum number we're perpared to receive. In this case, we'll set the
+# the maximum number we're prepared to receive. In this case, we'll set the
 # limit to 64, which means the largest encoded header block we can receive by
 # default is 262144 bytes long, and the largest possible *at all* is 1073741760
 # bytes long.
@@ -25,7 +25,7 @@ CONTINUATION_BACKLOG = 64
 
 class FrameBuffer:
     """
-    A buffer data structure for HTTP/2 data that allows iteraton in terms of
+    A buffer data structure for HTTP/2 data that allows iteration in terms of
     H2 frames.
     """
 
@@ -94,7 +94,7 @@ class FrameBuffer:
 
             # If this is the end of the header block, then we want to build a
             # mutant HEADERS frame that's massive. Use the original one we got,
-            # then set END_HEADERS and set its data appopriately. If it's not
+            # then set END_HEADERS and set its data appropriately. If it's not
             # the end of the block, lose the current frame: we can't yield it.
             if "END_HEADERS" in f.flags:
                 f = self._headers_buffer[0]

--- a/tests/test_flow_control_window.py
+++ b/tests/test_flow_control_window.py
@@ -730,7 +730,7 @@ class TestAutomaticFlowControl:
         frame_factory.refresh_encoder()
 
         # Create a connection in a state that might actually accept
-        # data acknolwedgement.
+        # data acknowledgement.
         c = self._setup_connection_and_send_headers(frame_factory)
         data_frame = frame_factory.build_data_frame(
             b"some data", flags=["END_STREAM"],
@@ -755,7 +755,7 @@ class TestAutomaticFlowControl:
         frame_factory.refresh_encoder()
 
         # Create a connection in a state that might actually accept
-        # data acknolwedgement.
+        # data acknowledgement.
         c = self._setup_connection_and_send_headers(frame_factory)
         data_frame = frame_factory.build_data_frame(
             b"some data", flags=["END_STREAM"],


### PR DESCRIPTION
Fix typos discovered by codespell - https://pypi.org/project/codespell

% `codespell --ignore-words-list=te`
```
./tests/test_flow_control_window.py:733: acknolwedgement ==> acknowledgement
./tests/test_flow_control_window.py:758: acknolwedgement ==> acknowledgement
./src/h2/connection.py:783: workds ==> works, words, worlds
./src/h2/events.py:513: acknowedged ==> acknowledged
./src/h2/frame_buffer.py:16: perpared ==> prepared
./src/h2/frame_buffer.py:28: iteraton ==> iteration
./src/h2/frame_buffer.py:97: appopriately ==> appropriately
```
% `codespell --ignore-words-list=te --write-changes` 