### PR TITLE
Broaden receive data buffer types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,9 @@ dev
 **API Changes (Backward Compatible)**
 
 - Support for Python 3.14 has been added.
+- ``H2Connection.receive_data`` now accepts any byte-like object that
+  implements the buffer protocol, such as ``bytes``, ``bytearray``, and
+  ``memoryview``. Existing ``bytes`` callers are unaffected.
 - Align CONNECT pseudo-header validation with RFC 9113 s8.3 and RFC 8441 s4.
   Ordinary CONNECT now requires ``:method=CONNECT`` and ``:authority``, and
   forbids ``:scheme``/``:path``. Extended CONNECT (e.g., WebSocket) requires

--- a/docs/source/basic-usage.rst
+++ b/docs/source/basic-usage.rst
@@ -311,6 +311,10 @@ socket, in a loop. We then passed that data to the connection object, which
 returned us a single event object:
 :class:`RemoteSettingsChanged <h2.events.RemoteSettingsChanged>`.
 
+``receive_data`` accepts the ``bytes`` returned by ``recv`` as well as other
+byte-like objects that implement the buffer protocol, such as ``bytearray`` and
+``memoryview``.
+
 But what we didn't see was anything else. So it seems like all ``curl`` did
 was change its settings, but nothing else. If you look at the other ``curl``
 window, you'll notice that it hangs for a while and then eventually fails with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ testing = [
 
 linting = [
   "ruff>=0.8.0,<1",
-  "mypy>=1.13.0,<2",
+  "mypy>=1.16.0,<2",
   "typing_extensions>=4.12.2",
 ]
 
@@ -149,6 +149,7 @@ testpaths = [ "tests" ]
 [tool.coverage.run]
 branch = true
 source = [ "h2" ]
+omit = [ "*/h2/_typing.py" ]
 
 [tool.coverage.report]
 fail_under = 100
@@ -190,7 +191,7 @@ commands = [
 dependency_groups = ["linting"]
 commands = [
   ["ruff", "check", "src/"],
-  ["mypy", "src/"],
+  ["mypy", "--strict-bytes", "src/", "tests/typing/strict_bytes.py"],
 ]
 
 [tool.tox.env.docs]

--- a/src/h2/_typing.py
+++ b/src/h2/_typing.py
@@ -1,0 +1,21 @@
+"""
+h2/_typing
+~~~~~~~~~~
+
+Shared typing helpers.
+"""
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class Buffer(Protocol):
+    """
+    An object implementing the PEP 688 buffer protocol.
+    """
+
+    def __buffer__(self, flags: int, /) -> memoryview:
+        """
+        Return a memoryview over this object's bytes.
+        """
+        ...

--- a/src/h2/connection.py
+++ b/src/h2/connection.py
@@ -70,6 +70,8 @@ if TYPE_CHECKING:  # pragma: no cover
 
     from hpack.struct import Header, HeaderWeaklyTyped
 
+    from ._typing import Buffer
+
 
 class ConnectionState(Enum):
     IDLE = 0
@@ -1496,12 +1498,12 @@ class H2Connection:
         for stream in self.streams.values():
             stream._inbound_flow_control_change_from_settings(delta)
 
-    def receive_data(self, data: bytes) -> list[Event]:
+    def receive_data(self, data: Buffer) -> list[Event]:
         """
         Pass some received HTTP/2 data to the connection for handling.
 
         :param data: The data received from the remote peer on the network.
-        :type data: ``bytes``
+        :type data: An object implementing the buffer protocol.
         :returns: A list of events that the remote peer triggered by sending
             this data.
         """

--- a/src/h2/frame_buffer.py
+++ b/src/h2/frame_buffer.py
@@ -7,10 +7,15 @@ frames.
 """
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from hyperframe.exceptions import InvalidDataError, InvalidFrameError
 from hyperframe.frame import ContinuationFrame, Frame, HeadersFrame, PushPromiseFrame
 
 from .exceptions import FrameDataMissingError, FrameTooLargeError, ProtocolError
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ._typing import Buffer
 
 # To avoid a DOS attack based on sending loads of continuation frames, we limit
 # the maximum number we're prepared to receive. In this case, we'll set the
@@ -36,25 +41,27 @@ class FrameBuffer:
         self._preamble_len = len(self._preamble)
         self._headers_buffer: list[HeadersFrame | ContinuationFrame | PushPromiseFrame] = []
 
-    def add_data(self, data: bytes) -> None:
+    def add_data(self, data: Buffer) -> None:
         """
         Add more data to the frame buffer.
 
         :param data: A bytestring containing the byte buffer.
         """
+        data_view = memoryview(data)
+
         if self._preamble_len:
-            data_len = len(data)
+            data_len = len(data_view)
             of_which_preamble = min(self._preamble_len, data_len)
 
-            if self._preamble[:of_which_preamble] != data[:of_which_preamble]:
+            if self._preamble[:of_which_preamble] != data_view[:of_which_preamble]:
                 msg = "Invalid HTTP/2 preamble."
                 raise ProtocolError(msg)
 
-            data = data[of_which_preamble:]
+            data_view = data_view[of_which_preamble:]
             self._preamble_len -= of_which_preamble
             self._preamble = self._preamble[of_which_preamble:]
 
-        self._data += data
+        self._data += data_view
 
     def _validate_frame_length(self, length: int) -> None:
         """

--- a/tests/test_basic_logic.py
+++ b/tests/test_basic_logic.py
@@ -1003,6 +1003,22 @@ class TestBasicServer:
         assert not events
         assert not c.data_to_send()
 
+    @pytest.mark.parametrize("data_wrapper", [bytearray, memoryview])
+    def test_receive_data_accepts_buffer_types(
+        self,
+        data_wrapper,
+        frame_factory,
+    ) -> None:
+        """
+        ``receive_data`` accepts byte-like buffers and handles their contents.
+        """
+        c = h2.connection.H2Connection(config=self.server_config)
+
+        events = c.receive_data(data_wrapper(frame_factory.preamble()))
+
+        assert not events
+        assert not c.data_to_send()
+
     @pytest.mark.parametrize("chunk_size", range(1, 24))
     def test_drip_feed_preamble(self, chunk_size) -> None:
         """

--- a/tests/typing/strict_bytes.py
+++ b/tests/typing/strict_bytes.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from h2.connection import H2Connection
+from h2.frame_buffer import FrameBuffer
+
+
+def receive_data_accepts_buffer_types(
+    connection: H2Connection,
+    frame_buffer: FrameBuffer,
+) -> None:
+    bytearray_data = bytearray(b"")
+    memoryview_data = memoryview(b"")
+
+    connection.receive_data(bytearray_data)
+    connection.receive_data(memoryview_data)
+    frame_buffer.add_data(bytearray_data)
+    frame_buffer.add_data(memoryview_data)

--- a/tests/typing/strict_bytes.py
+++ b/tests/typing/strict_bytes.py
@@ -1,17 +1,28 @@
 from __future__ import annotations
 
+from hyperframe.frame import Frame
+from typing_extensions import assert_type
+
 from h2.connection import H2Connection
+from h2.events import Event
 from h2.frame_buffer import FrameBuffer
 
 
-def receive_data_accepts_buffer_types(
-    connection: H2Connection,
-    frame_buffer: FrameBuffer,
-) -> None:
+def receive_data_accepts_buffer_types() -> None:
+    connection = H2Connection()
+    frame_buffer = FrameBuffer()
     bytearray_data = bytearray(b"")
     memoryview_data = memoryview(b"")
 
-    connection.receive_data(bytearray_data)
-    connection.receive_data(memoryview_data)
+    bytearray_events = connection.receive_data(bytearray_data)
+    memoryview_events = connection.receive_data(memoryview_data)
     frame_buffer.add_data(bytearray_data)
     frame_buffer.add_data(memoryview_data)
+    buffered_frames = list(frame_buffer)
+
+    assert_type(bytearray_events, list[Event])
+    assert_type(memoryview_events, list[Event])
+    assert_type(buffered_frames, list[Frame])
+    assert bytearray_events == []
+    assert memoryview_events == []
+    assert buffered_frames == []


### PR DESCRIPTION
## Summary

- Broaden `H2Connection.receive_data` and `FrameBuffer.add_data` annotations from `bytes` to a local PEP 688-style `Buffer` protocol.
- Normalize frame buffer input through `memoryview` so byte-like inputs are handled consistently.
- Add a strict-bytes mypy fixture covering `bytearray` and `memoryview`, and run it in the lint tox environment.

Fixes #1305.

## Validation

Local CI-equivalent checks run before advancing this draft:

- `uv run --no-project --with tox --with tox-gh-actions tox -e py311`
- `uv run --no-project --with tox --with tox-gh-actions tox -e lint`
- `uv run --no-project --with tox --with tox-gh-actions tox -e py310,py312,py313,py314,packaging`
- `uv run --python 3.13 --no-project --with tox --with tox-gh-actions tox -r -e docs`

Upstream GitHub Actions note: the PR's `CI` workflow is currently `action_required` with no jobs, so it has not executed on GitHub yet. The remaining `h2spec` job is Linux-specific in the workflow because it downloads a Linux h2spec binary, so I could not reproduce that exact job on this macOS workspace.