### PR TITLE
Reject conflicting duplicate Content-Length headers

### DIFF
--- a/src/h2/stream.py
+++ b/src/h2/stream.py
@@ -1364,15 +1364,23 @@ class H2Stream:
             self._expected_content_length = 0
             return
 
+        content_length = None
         for n, v in headers:
             if n == b"content-length":
                 try:
-                    self._expected_content_length = int(v, 10)
+                    header_content_length = int(v, 10)
                 except ValueError as err:
                     msg = f"Invalid content-length header: {v!r}"
                     raise ProtocolError(msg) from err
 
-                return
+                if content_length is not None and header_content_length != content_length:
+                    msg = "Conflicting content-length headers received"
+                    raise ProtocolError(msg)
+
+                content_length = header_content_length
+
+        if content_length is not None:
+            self._expected_content_length = content_length
 
     def _track_content_length(self, length: int, end_stream: bool) -> None:
         """

--- a/tests/test_invalid_content_lengths.py
+++ b/tests/test_invalid_content_lengths.py
@@ -40,6 +40,60 @@ class TestInvalidContentLengths:
     server_config = h2.config.H2Configuration(client_side=False)
 
     @pytest.mark.parametrize("request_headers", [example_request_headers, example_request_headers_bytes])
+    def test_duplicate_matching_content_length(self, frame_factory, request_headers) -> None:
+        """
+        Remote peers sending duplicate matching content-length headers are
+        accepted.
+        """
+        c = h2.connection.H2Connection(config=self.server_config)
+        c.initiate_connection()
+        c.receive_data(frame_factory.preamble())
+        c.clear_outbound_data_buffer()
+
+        headers = frame_factory.build_headers_frame(
+            headers=[*request_headers, request_headers[-1]],
+        )
+        data = frame_factory.build_data_frame(
+            data=b"\x01"*15,
+            flags=["END_STREAM"],
+        )
+        events = c.receive_data(headers.serialize() + data.serialize())
+
+        assert isinstance(events[0], h2.events.RequestReceived)
+        assert isinstance(events[1], h2.events.DataReceived)
+        assert isinstance(events[2], h2.events.StreamEnded)
+        assert not c.data_to_send()
+
+    @pytest.mark.parametrize(
+        ("request_headers", "conflicting_header"),
+        [
+            (example_request_headers, ("content-length", "14")),
+            (example_request_headers_bytes, (b"content-length", b"14")),
+        ],
+    )
+    def test_duplicate_conflicting_content_length(self, frame_factory, request_headers, conflicting_header) -> None:
+        """
+        Remote peers sending duplicate conflicting content-length headers cause
+        Protocol Errors.
+        """
+        c = h2.connection.H2Connection(config=self.server_config)
+        c.initiate_connection()
+        c.receive_data(frame_factory.preamble())
+        c.clear_outbound_data_buffer()
+
+        headers = frame_factory.build_headers_frame(
+            headers=[*request_headers, conflicting_header],
+        )
+        with pytest.raises(h2.exceptions.ProtocolError, match="Conflicting content-length"):
+            c.receive_data(headers.serialize())
+
+        expected_frame = frame_factory.build_goaway_frame(
+            last_stream_id=1,
+            error_code=h2.errors.ErrorCodes.PROTOCOL_ERROR,
+        )
+        assert c.data_to_send() == expected_frame.serialize()
+
+    @pytest.mark.parametrize("request_headers", [example_request_headers, example_request_headers_bytes])
     def test_too_much_data(self, frame_factory, request_headers) -> None:
         """
         Remote peers sending data in excess of content-length causes Protocol


### PR DESCRIPTION
## Summary
- validate all inbound `content-length` header fields before initializing the expected body length
- accept duplicate `content-length` headers only when all values agree
- add coverage for matching and conflicting duplicate `content-length` request headers

Closes #1316.

## Validation
- `git diff --check`
- Not run locally