### PR TITLE
Remove consumed frames in place

### DIFF
--- a/src/h2/frame_buffer.py
+++ b/src/h2/frame_buffer.py
@@ -155,6 +155,13 @@ class FrameBuffer:
 
         # At this point, as we know we'll use or discard the entire frame, we
         # can update the data.
+        # Deleting the consumed prefix mutates the bytearray in place instead
+        # of copying the remaining bytes into a new object, as slicing would.
+        # ``del s[i:j]`` is documented for mutable sequences in
+        # https://docs.python.org/3/library/stdtypes.html#mutable-sequence-types
+        # and CPython's bytearray tracks an internal offset (``ob_start`` in
+        # Objects/bytearrayobject.c) that makes repeated deletes from the
+        # front amortized O(1) per byte rather than O(len) per frame.
         del self._data[:9+length]
 
         # Pass the frame through the header buffer.

--- a/src/h2/frame_buffer.py
+++ b/src/h2/frame_buffer.py
@@ -155,7 +155,7 @@ class FrameBuffer:
 
         # At this point, as we know we'll use or discard the entire frame, we
         # can update the data.
-        self._data = self._data[9+length:]
+        del self._data[:9+length]
 
         # Pass the frame through the header buffer.
         new_frame = self._update_header_buffer(f)

--- a/tests/test_basic_logic.py
+++ b/tests/test_basic_logic.py
@@ -23,6 +23,20 @@ import h2.stream
 from . import helpers
 
 
+class TestFrameBuffer:
+    def test_consumed_frames_are_removed_in_place(self) -> None:
+        frame = hyperframe.frame.SettingsFrame(0).serialize()
+        buffer = h2.frame_buffer.FrameBuffer()
+        buffer.max_frame_size = 65535
+        buffer.add_data(frame * 2)
+        data = buffer._data
+
+        next(buffer)
+
+        assert buffer._data is data
+        assert buffer._data == frame
+
+
 class TestBasicClient:
     """
     Basic client-side tests.

--- a/tests/test_basic_logic.py
+++ b/tests/test_basic_logic.py
@@ -33,6 +33,10 @@ class TestFrameBuffer:
 
         next(buffer)
 
+        # ``is`` checks object identity (CPython compares ``id(...)`` of both
+        # operands): the buffer must still be the very same bytearray object,
+        # proving the consumed frame was deleted in place rather than the
+        # buffer being replaced by a sliced copy.
         assert buffer._data is data
         assert buffer._data == frame
 


### PR DESCRIPTION
Closes #474.

`FrameBuffer` now stores incoming bytes in a `bytearray`, but consuming a frame still assigns `self._data[9 + length:]` back to the attribute. That creates and copies a new buffer for every frame, so parsing many buffered frames remains quadratic.

Delete the consumed prefix in place instead. CPython's optimized left deletion can then advance the bytearray start offset without copying the full remaining suffix. A regression test verifies both that the same bytearray object is retained and that the next frame remains buffered.

Benchmark

I buffered repeated valid, empty SETTINGS frames and then iterated the `FrameBuffer` on CPython 3.11 / Windows:

| Frames | Before | After | Speedup |
| ---: | ---: | ---: | ---: |
| 50,000 | 0.935s | 0.157s | 6.0x |
| 100,000 | 4.018s | 0.322s | 12.5x |
| 200,000 | 40.451s | 0.641s | 63.1x |

The post-change throughput stays near 312,000 frames/s across the three input sizes.

Validation

- `python -m pytest` — 1,654 passed
- `python -m mypy --strict-bytes src tests/typing/strict_bytes.py`
- Ruff on the changed source and test (excluding three unrelated existing findings in `test_basic_logic.py`)
- `git diff --check`